### PR TITLE
Refactored Video Calling to be similar to Screen Sharing implementation; replaced raw HTML with Redux.

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -7,31 +7,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="./src/index.css">
     <title>Phaser React Template</title>
-    <style>
-        #video-container {
-            display: grid;
-            grid-template-columns: repeat(auto-fill, 160px);
-            grid-gap: 5px;
-            grid-auto-rows: 160px;
-            position: absolute;
-            top: 35px;
-            left: 10px;
-            max-height: calc(100% - 100px);
-            overflow-y: auto;
-        }
-
-        #video-container video {
-            width: 100%;
-            height: 100%;
-            object-fit: cover;
-            border-radius: 5px;
-            border: 1px groove rgb(229, 251, 255);
-        }
-    </style>
 </head>
 
 <body>
-    <div id="video-container"></div>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,6 +5,7 @@ import ScreenShare from "./components/ScreenShare";
 import { useState } from "react";
 import FloatingActions from "./components/FloatingActions";
 import { AnimatePresence } from "framer-motion";
+import VideoCall from "./components/VideoCall";
 
 function App() {
     const roomJoined = useAppSelector((state) => state.room.roomJoined);
@@ -25,10 +26,13 @@ function App() {
             </AnimatePresence>
 
             {showOfficeChat && (
-                <ScreenShare
-                    screenDialogOpen={screenDialogOpen}
-                    setScreenDialogOpen={setScreenDialogOpen}
-                />
+                <>
+                    <VideoCall />
+                    <ScreenShare
+                        screenDialogOpen={screenDialogOpen}
+                        setScreenDialogOpen={setScreenDialogOpen}
+                    />
+                </>
             )}
         </>
     );

--- a/client/src/app/features/webRtc/screenSlice.ts
+++ b/client/src/app/features/webRtc/screenSlice.ts
@@ -1,5 +1,5 @@
 import phaserGame from "../../../game/main";
-import { sanitizeUserId } from "../../../lib/utils";
+import { sanitizeUserIdForScreenSharing } from "../../../lib/utils";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { MediaConnection } from "peerjs";
 import { GameScene } from "../../../game/scenes/GameScene";
@@ -40,8 +40,11 @@ const screenReducer = createSlice({
             state.peerStreams.set(peerId, { call, stream, username });
         },
         /** disconnect remote player when he leaves the office. */
-        disconnectUser: (state, action: PayloadAction<string>) => {
-            const sanitizedId = sanitizeUserId(action.payload);
+        disconnectUserForScreenSharing: (
+            state,
+            action: PayloadAction<string>
+        ) => {
+            const sanitizedId = sanitizeUserIdForScreenSharing(action.payload);
 
             const peer = state.peerStreams.get(sanitizedId);
             peer.call.close();
@@ -51,7 +54,7 @@ const screenReducer = createSlice({
          * disconnect all the connected peers with current player
          * and stops his stream when he leaves the office.
          */
-        removeAllPeerConnections: (state) => {
+        removeAllPeerConnectionsForScreenSharing: (state) => {
             if (state.myScreenStream) {
                 const tracks = state.myScreenStream.getTracks();
                 tracks.forEach((track) => track.stop());
@@ -99,8 +102,8 @@ const screenReducer = createSlice({
 export const {
     setMyScreenStream,
     addScreenStream,
-    disconnectUser,
-    removeAllPeerConnections,
+    disconnectUserForScreenSharing,
+    removeAllPeerConnectionsForScreenSharing,
     stopScreenSharing,
     setPlayerNameMap,
     removePlayerNameMap,

--- a/client/src/components/FloatingActions.tsx
+++ b/client/src/components/FloatingActions.tsx
@@ -10,12 +10,18 @@ import {
     TooltipTrigger,
 } from "./ui/tooltip";
 import { AnimatePresence, motion } from "framer-motion";
+import phaserGame from "../game/main";
+import { GameScene } from "../game/scenes/GameScene";
+import { toast } from "sonner";
 
 const FloatingActions = ({
     setScreenDialogOpen,
 }: {
     setScreenDialogOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }) => {
+    const myWebcamStream = useAppSelector(
+        (state) => state.webcam.myWebcamStream
+    );
     const isWebcamOn = useAppSelector((state) => state.webcam.isWebcamOn);
     const isMicOn = useAppSelector((state) => state.webcam.isMicOn);
 
@@ -51,28 +57,120 @@ const FloatingActions = ({
                     </TooltipContent>
                 </Tooltip>
 
-                {/* Webcam */}
-                <Tooltip>
-                    <TooltipTrigger asChild>
-                        <Button
-                            variant="outline"
-                            className="cursor-pointer transition-all ease-in-out"
-                            onClick={() => {
-                                store.dispatch(toggleWebcam());
-                            }}
-                        >
-                            <AnimatePresence mode="wait" initial={false}>
-                                {isWebcamOn ? (
-                                    <motion.div
-                                        key="webcam"
-                                        initial={{ opacity: 0 }}
-                                        animate={{ opacity: 1 }}
-                                        exit={{ opacity: 0 }}
-                                        transition={{ duration: 0.2 }}
+                {myWebcamStream ? (
+                    // Player has given access to his webcam
+                    <>
+                        {/* Webcam */}
+                        <Tooltip>
+                            <TooltipTrigger asChild>
+                                <Button
+                                    variant="outline"
+                                    className="cursor-pointer transition-all ease-in-out"
+                                    onClick={() => {
+                                        store.dispatch(toggleWebcam());
+                                    }}
+                                >
+                                    <AnimatePresence
+                                        mode="wait"
+                                        initial={false}
                                     >
-                                        <Camera />
-                                    </motion.div>
-                                ) : (
+                                        {isWebcamOn ? (
+                                            <motion.div
+                                                key="webcam"
+                                                initial={{ opacity: 0 }}
+                                                animate={{ opacity: 1 }}
+                                                exit={{ opacity: 0 }}
+                                                transition={{ duration: 0.2 }}
+                                            >
+                                                <Camera />
+                                            </motion.div>
+                                        ) : (
+                                            <motion.div
+                                                key="mic-off"
+                                                initial={{ opacity: 0 }}
+                                                animate={{ opacity: 1 }}
+                                                exit={{ opacity: 0 }}
+                                                transition={{ duration: 0.2 }}
+                                            >
+                                                <CameraOff />
+                                            </motion.div>
+                                        )}
+                                    </AnimatePresence>
+                                </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                                <p className="text-black">
+                                    {isWebcamOn
+                                        ? "Turn off camera"
+                                        : "Turn on camera"}
+                                </p>
+                            </TooltipContent>
+                        </Tooltip>
+
+                        {/* Mic */}
+                        <Tooltip>
+                            <TooltipTrigger asChild>
+                                <Button
+                                    variant="outline"
+                                    className="cursor-pointer transition-all ease-in-out"
+                                    onClick={() => {
+                                        store.dispatch(toggleMic());
+                                    }}
+                                >
+                                    <AnimatePresence
+                                        mode="wait"
+                                        initial={false}
+                                    >
+                                        {isMicOn ? (
+                                            <motion.div
+                                                key="mic"
+                                                initial={{ opacity: 0 }}
+                                                animate={{ opacity: 1 }}
+                                                exit={{ opacity: 0 }}
+                                                transition={{ duration: 0.2 }}
+                                            >
+                                                <Mic />
+                                            </motion.div>
+                                        ) : (
+                                            <motion.div
+                                                key="mic-off"
+                                                initial={{ opacity: 0 }}
+                                                animate={{ opacity: 1 }}
+                                                exit={{ opacity: 0 }}
+                                                transition={{ duration: 0.2 }}
+                                            >
+                                                <MicOff />
+                                            </motion.div>
+                                        )}
+                                    </AnimatePresence>
+                                </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                                <p className="text-black">
+                                    {isMicOn ? "Turn off mic" : "Turn on mic"}
+                                </p>
+                            </TooltipContent>
+                        </Tooltip>
+                    </>
+                ) : (
+                    // Player has not given access to his webcam
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <Button
+                                variant="outline"
+                                className="cursor-pointer transition-all ease-in-out"
+                                onClick={async () => {
+                                    const gameInstance = phaserGame.scene.keys
+                                        .GameScene as GameScene;
+                                    await gameInstance.network.startWebcam();
+                                    toast(
+                                        <div className="font-semibold">
+                                            Started Webcam
+                                        </div>
+                                    );
+                                }}
+                            >
+                                <AnimatePresence mode="wait" initial={false}>
                                     <motion.div
                                         key="mic-off"
                                         initial={{ opacity: 0 }}
@@ -82,58 +180,18 @@ const FloatingActions = ({
                                     >
                                         <CameraOff />
                                     </motion.div>
-                                )}
-                            </AnimatePresence>
-                        </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                        <p className="text-black">
-                            {isWebcamOn ? "Turn off camera" : "Turn on camera"}
-                        </p>
-                    </TooltipContent>
-                </Tooltip>
-
-                {/* Mic */}
-                <Tooltip>
-                    <TooltipTrigger asChild>
-                        <Button
-                            variant="outline"
-                            className="cursor-pointer transition-all ease-in-out"
-                            onClick={() => {
-                                store.dispatch(toggleMic());
-                            }}
-                        >
-                            <AnimatePresence mode="wait" initial={false}>
-                                {isMicOn ? (
-                                    <motion.div
-                                        key="mic"
-                                        initial={{ opacity: 0 }}
-                                        animate={{ opacity: 1 }}
-                                        exit={{ opacity: 0 }}
-                                        transition={{ duration: 0.2 }}
-                                    >
-                                        <Mic />
-                                    </motion.div>
-                                ) : (
-                                    <motion.div
-                                        key="mic-off"
-                                        initial={{ opacity: 0 }}
-                                        animate={{ opacity: 1 }}
-                                        exit={{ opacity: 0 }}
-                                        transition={{ duration: 0.2 }}
-                                    >
-                                        <MicOff />
-                                    </motion.div>
-                                )}
-                            </AnimatePresence>
-                        </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                        <p className="text-black">
-                            {isMicOn ? "Turn off mic" : "Turn on mic"}
-                        </p>
-                    </TooltipContent>
-                </Tooltip>
+                                </AnimatePresence>
+                            </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                            <p className="text-black">
+                                {isWebcamOn
+                                    ? "Turn off camera"
+                                    : "Turn on camera"}
+                            </p>
+                        </TooltipContent>
+                    </Tooltip>
+                )}
             </TooltipProvider>
         </motion.div>
     );

--- a/client/src/components/ScreenShare.tsx
+++ b/client/src/components/ScreenShare.tsx
@@ -95,7 +95,7 @@ const ScreenShare = ({
                         {peerStreams.size > 0 || myStream ? (
                             <>
                                 {myStream && (
-                                    <Card className="">
+                                    <Card>
                                         <CardHeader>
                                             <CardTitle className="truncate">
                                                 Your Screen

--- a/client/src/components/VideoCall.tsx
+++ b/client/src/components/VideoCall.tsx
@@ -1,0 +1,32 @@
+import { useAppSelector } from "../app/hooks";
+import { VideoPlayer } from "./VideoPlayer";
+
+const VideoCall = () => {
+    const myWebcamStream = useAppSelector(
+        (state) => state.webcam.myWebcamStream
+    );
+    const peerStreams = useAppSelector((state) => state.webcam.peerStreams);
+
+    return (
+        <div className="absolute left-[35px] top-[10px] h-screen flex flex-col flex-wrap gap-2">
+            {myWebcamStream && (
+                <VideoPlayer
+                    stream={myWebcamStream}
+                    className="w-48 border-2"
+                    // muting own video
+                    muted
+                />
+            )}
+            {Array.from(peerStreams.entries()).map(([key, value]) => {
+                return (
+                    <VideoPlayer
+                        stream={value.stream}
+                        className="w-48 border-2"
+                    />
+                );
+            })}
+        </div>
+    );
+};
+
+export default VideoCall;

--- a/client/src/components/VideoPlayer.tsx
+++ b/client/src/components/VideoPlayer.tsx
@@ -1,9 +1,15 @@
 import { useEffect, useRef } from "react";
 
-export const VideoPlayer: React.FC<{
+interface VideoPlayerProps extends React.VideoHTMLAttributes<HTMLVideoElement> {
     stream: MediaProvider;
     className?: string;
-}> = ({ stream, className }) => {
+}
+
+export const VideoPlayer: React.FC<VideoPlayerProps> = ({
+    stream,
+    className,
+    ...props
+}) => {
     const videoRef = useRef<HTMLVideoElement>(null);
 
     useEffect(() => {
@@ -19,6 +25,7 @@ export const VideoPlayer: React.FC<{
             autoPlay
             playsInline
             className={`rounded-lg ${className && className}`}
+            {...props}
         />
     );
 };

--- a/client/src/game/service/ScreenSharing.ts
+++ b/client/src/game/service/ScreenSharing.ts
@@ -1,4 +1,4 @@
-import { sanitizeUserId } from "../../lib/utils";
+import { sanitizeUserIdForScreenSharing } from "../../lib/utils";
 import {
     addScreenStream,
     setMyScreenStream,
@@ -39,7 +39,7 @@ class ScreenSharing {
 
         // Create a new initialization promise
         this.initializationPromise = new Promise((resolve, reject) => {
-            const sanitizedId = sanitizeUserId(userId);
+            const sanitizedId = sanitizeUserIdForScreenSharing(userId);
             const peer = new Peer(sanitizedId);
 
             peer.on("open", (id) => {
@@ -49,10 +49,8 @@ class ScreenSharing {
             });
 
             peer.on("call", (call) => {
-                console.log("in oncall in screen sharing...");
                 call.answer();
                 call.on("stream", (userStream) => {
-                    console.log("screen stream Received");
                     store.dispatch(
                         addScreenStream({ peerId: call.peer, call, userStream })
                     );
@@ -76,12 +74,12 @@ class ScreenSharing {
 
         const myScreenStream = store.getState().screen.myScreenStream;
         if (!myScreenStream) {
-            console.log("user is not sharing his screen");
+            console.log("player is not sharing his screen");
             return;
         }
 
         try {
-            const userId = sanitizeUserId(sessionId);
+            const userId = sanitizeUserIdForScreenSharing(sessionId);
             console.log(
                 `${"calling: " + userId + " with my id: " + this.peer.id}`
             );
@@ -92,7 +90,7 @@ class ScreenSharing {
         }
     }
 
-    async getUserDisplayMedia() {
+    async getUserMedia() {
         const stream = await navigator.mediaDevices.getDisplayMedia();
         store.dispatch(setMyScreenStream(stream));
 
@@ -100,17 +98,8 @@ class ScreenSharing {
 
         // this is callled when player uses browser provided "stop screen sharing" button.
         track.onended = () => {
-            console.log("user stopped his screen.");
             store.dispatch(stopScreenSharing());
         };
-    }
-
-    public destroyPeer(): void {
-        if (this.peer) {
-            this.peer.destroy();
-            this.peer = null;
-            this.initializationPromise = null;
-        }
     }
 }
 

--- a/client/src/game/service/VideoCalling.ts
+++ b/client/src/game/service/VideoCalling.ts
@@ -1,20 +1,15 @@
+import { sanitizeUserIdForVideoCalling } from "../../lib/utils";
 import {
+    addWebcamStream,
     setMyWebcamStream,
-    turnOffWebcamAndMic,
 } from "../../app/features/webRtc/webcamSlice";
 import store from "../../app/store";
-import Peer, { MediaConnection } from "peerjs";
+import Peer from "peerjs";
 
 class VideoCalling {
     private static instance: VideoCalling;
-    private connectedPeers = new Map<
-        string,
-        { call: MediaConnection; video: HTMLVideoElement }
-    >();
     private peer: Peer | null = null;
     private initializationPromise: Promise<Peer> | null = null;
-    private videoContainer = document.querySelector("#video-container");
-    private myVideo = document.createElement("video");
 
     private constructor() {}
 
@@ -42,9 +37,8 @@ class VideoCalling {
 
         // Create a new initialization promise
         this.initializationPromise = new Promise((resolve, reject) => {
-            const sanitizedId = this.sanitizeUserId(userId);
+            const sanitizedId = sanitizeUserIdForVideoCalling(userId);
             const peer = new Peer(sanitizedId);
-            this.myVideo.muted = true; // muting own video
 
             peer.on("open", (id) => {
                 this.peer = peer;
@@ -53,14 +47,12 @@ class VideoCalling {
             });
 
             peer.on("call", (call) => {
-                if (!this.connectedPeers.has(call.peer)) {
-                    call.answer(store.getState().webcam.myWebcamStream);
-                    const video = document.createElement("video");
-                    this.connectedPeers.set(call.peer, { call, video });
-                    call.on("stream", (userStream) => {
-                        this.addVideoStream(video, userStream);
-                    });
-                }
+                call.answer();
+                call.on("stream", (userStream) => {
+                    store.dispatch(
+                        addWebcamStream({ peerId: call.peer, call, userStream })
+                    );
+                });
             });
 
             peer.on("error", (error) => {
@@ -72,100 +64,39 @@ class VideoCalling {
         return this.initializationPromise;
     }
 
-    // PeerJS throws invalid_id error if it contains some characters such as that colyseus generates.
-    // https://peerjs.com/docs.html#peer-id
-    private sanitizeUserId(userId: string) {
-        return userId.replace(/[^0-9a-z]/gi, "X");
-    }
-
-    public async connectToNewUser(userId: string): Promise<void> {
+    public shareWebcam(sessionId: string) {
         if (!this.peer) {
             console.error("Cannot call peer - Peer not initialized");
             throw new Error("Peer not initialized");
         }
 
-        console.log("Calling peer:", userId, "with my ID:", this.peer.id);
+        const myWebcamStream = store.getState().webcam.myWebcamStream;
+        if (!myWebcamStream) {
+            console.log("player is not sharing his webcam");
+            return;
+        }
 
         try {
-            // Make the call
-            const call = this.peer.call(
-                userId,
-                store.getState().webcam.myWebcamStream
+            const userId = sanitizeUserIdForVideoCalling(sessionId);
+            console.log(
+                `${"calling: " + userId + " with my id: " + this.peer.id}`
             );
-
-            if (call) {
-                const video = document.createElement("video");
-
-                this.connectedPeers.set(userId, { call, video });
-
-                // Handle the stream when we get it
-                call.on("stream", (remoteStream) => {
-                    console.log("Received stream from called peer:", userId);
-                    this.addVideoStream(video, remoteStream);
-                });
-
-                // Handle call closure
-                call.on("close", () => {
-                    console.log("Call to", userId, "closed");
-                });
-            }
+            this.peer.call(userId, myWebcamStream);
         } catch (err) {
-            console.error("Error calling peer", userId, ":", err);
+            console.error("Error while sharing screen: ", err);
             throw err;
         }
     }
 
-    // TODO: Remove video when user closes the site when he's inside of office.
-    // disconnect remote player when he leaves the office.
-    public disconnectUser(userId: string) {
-        const sanitizedId = this.sanitizeUserId(userId);
-
-        if (this.connectedPeers.has(sanitizedId)) {
-            const peer = this.connectedPeers.get(sanitizedId);
-            peer.call.close();
-            peer.video.remove();
-            this.connectedPeers.delete(sanitizedId);
-        }
-    }
-
-    // disconnect all the connected peers with current player when he leaves the office.
-    public removeAllPeerConnections() {
-        // if condition is required otherwise an infinite loops starts
-        // if user leaves the office without giving access to his webcam.
-        if (store.getState().webcam.myWebcamStream) {
-            store.dispatch(turnOffWebcamAndMic());
-            this.myVideo.remove();
-        }
-
-        this.connectedPeers.forEach((peer) => {
-            peer.call.close();
-            peer.video.remove();
+    getUserMedia = async () => {
+        const stream = await navigator.mediaDevices.getUserMedia({
+            audio: true,
+            video: true,
         });
 
-        this.connectedPeers.clear();
-    }
-
-    private addVideoStream(video: HTMLVideoElement, stream: MediaStream) {
-        video.srcObject = stream;
-        video.playsInline = true;
-        video.addEventListener("loadeddata", () => video.play());
-
-        if (this.videoContainer) {
-            this.videoContainer.appendChild(video);
-        }
-    }
-
-    getUserMedia() {
-        navigator.mediaDevices
-            .getUserMedia({
-                audio: true,
-                video: true,
-            })
-            .then((stream) => {
-                store.dispatch(setMyWebcamStream(stream));
-                this.addVideoStream(this.myVideo, stream);
-            });
-    }
+        store.dispatch(setMyWebcamStream(stream));
+        // this.addVideoStream(this.myVideo, stream);
+    };
 }
 
 export default VideoCalling.getInstance();

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -7,8 +7,14 @@ export function cn(...inputs: ClassValue[]) {
 
 // PeerJS throws invalid_id error if it contains some characters such as that colyseus generates.
 // https://peerjs.com/docs.html#peer-id
+export const sanitizeUserIdForVideoCalling = (userId: string) => {
+    return userId.replace(/[^0-9a-z]/gi, "X");
+};
+
+// PeerJS throws invalid_id error if it contains some characters such as that colyseus generates.
+// https://peerjs.com/docs.html#peer-id
 // appending '-ss' at the end of the id. It is for screen sharing.
-export const sanitizeUserId = (userId: string) => {
+export const sanitizeUserIdForScreenSharing = (userId: string) => {
     return `${userId.replace(/[^0-9a-z]/gi, "X")}-ss`;
 };
 

--- a/server/src/rooms/MyRoom.ts
+++ b/server/src/rooms/MyRoom.ts
@@ -86,7 +86,10 @@ export class MyRoom extends Room<MyRoomState> {
                 members.has(member.sessionId) &&
                 member.sessionId !== client.sessionId
             ) {
-                member.send("CONNECT_TO_WEBRTC", { peerId, username });
+                member.send("CONNECT_TO_WEBRTC", {
+                    peerId: client.sessionId,
+                    username,
+                });
             }
         });
 


### PR DESCRIPTION
Updated Video Calling implementation to work very similar how Screen Sharing works.

Now when user enters an office, he's not immediately asked for webcam permission. All the present users of the office who has given their webcam access calls the newly joined user and newly joined user answers their call and displays their webcam. 

Now when user clicks on the camera button, he's asked for webcam permission and after giving permission, he calls all the present users of the office and shares his webcam stream with them, this is very similar to how screen sharing is implemented. 

When user leaves the office and joins again, it is checked if he previously has given his webcam access or not, if he has given it then no need to ask for permission again, he can directly turn on/off his webcam/mic.

Removed raw HTML usage and moved all logic to `webcamSlice.ts` with Redux usage.