### PR TITLE
Added support to disconnect from video calls when in office

### DIFF
--- a/client/src/app/features/webRtc/webcamSlice.ts
+++ b/client/src/app/features/webRtc/webcamSlice.ts
@@ -67,13 +67,32 @@ const webcamSlice = createSlice({
             state.peerStreams.delete(sanitizedId);
         },
         /**
-         * disconnect all the connected peers with current player
-         * and stops his stream when he leaves the office.
+         * Disconnect all the connected peers with current player.
+         *
+         * Used when player leaves an office.
          */
         removeAllPeerConnectionsForVideoCalling: (state) => {
             if (state.myWebcamStream) {
                 state.myWebcamStream.getVideoTracks()[0].enabled = false;
                 state.myWebcamStream.getAudioTracks()[0].enabled = false;
+                state.isWebcamOn = false;
+                state.isMicOn = false;
+            }
+
+            state.peerStreams.forEach((peer) => {
+                peer.call.close();
+            });
+
+            state.peerStreams.clear();
+        },
+        /**
+         * disconnect all the connected peers with current player.
+         *
+         * Used when player clicks on "Disconnect from video calls" button.
+         */
+        disconnectFromVideoCall: (state) => {
+            if (state.myWebcamStream) {
+                state.myWebcamStream = null;
                 state.isWebcamOn = false;
                 state.isMicOn = false;
             }
@@ -95,6 +114,7 @@ export const {
     addWebcamStream,
     disconnectUserForVideoCalling,
     removeAllPeerConnectionsForVideoCalling,
+    disconnectFromVideoCall,
 } = webcamSlice.actions;
 
 export default webcamSlice.reducer;

--- a/client/src/components/FloatingActions.tsx
+++ b/client/src/components/FloatingActions.tsx
@@ -1,7 +1,14 @@
 import store from "../app/store";
 import { useAppSelector } from "../app/hooks";
 import { Button } from "./ui/button";
-import { Camera, CameraOff, Mic, MicOff, ScreenShare } from "lucide-react";
+import {
+    Camera,
+    CameraOff,
+    Mic,
+    MicOff,
+    PhoneOff,
+    ScreenShare,
+} from "lucide-react";
 import { toggleMic, toggleWebcam } from "../app/features/webRtc/webcamSlice";
 import {
     Tooltip,
@@ -13,12 +20,15 @@ import { AnimatePresence, motion } from "framer-motion";
 import phaserGame from "../game/main";
 import { GameScene } from "../game/scenes/GameScene";
 import { toast } from "sonner";
+import { useState } from "react";
 
 const FloatingActions = ({
     setScreenDialogOpen,
 }: {
     setScreenDialogOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }) => {
+    const [shouldConnectToOtherPlayers, setShouldConnectToOtherPlayers] =
+        useState(false);
     const myWebcamStream = useAppSelector(
         (state) => state.webcam.myWebcamStream
     );
@@ -151,6 +161,47 @@ const FloatingActions = ({
                                 </p>
                             </TooltipContent>
                         </Tooltip>
+
+                        {/* Disconnect */}
+                        <Tooltip>
+                            <TooltipTrigger asChild>
+                                <Button
+                                    variant="destructive"
+                                    className="cursor-pointer transition-all ease-in-out"
+                                    onClick={() => {
+                                        const gameInstance = phaserGame.scene
+                                            .keys.GameScene as GameScene;
+                                        gameInstance.network.playerStoppedWebcam();
+                                        setShouldConnectToOtherPlayers(true);
+                                        toast(
+                                            <div className="font-semibold">
+                                                Disconnected from video calls
+                                            </div>
+                                        );
+                                    }}
+                                >
+                                    <AnimatePresence
+                                        mode="wait"
+                                        initial={false}
+                                    >
+                                        <motion.div
+                                            key="mic-off"
+                                            initial={{ opacity: 0 }}
+                                            animate={{ opacity: 1 }}
+                                            exit={{ opacity: 0 }}
+                                            transition={{ duration: 0.2 }}
+                                        >
+                                            <PhoneOff />
+                                        </motion.div>
+                                    </AnimatePresence>
+                                </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                                <p className="text-black">
+                                    Disconnect From Video Calls
+                                </p>
+                            </TooltipContent>
+                        </Tooltip>
                     </>
                 ) : (
                     // Player has not given access to his webcam
@@ -162,10 +213,12 @@ const FloatingActions = ({
                                 onClick={async () => {
                                     const gameInstance = phaserGame.scene.keys
                                         .GameScene as GameScene;
-                                    await gameInstance.network.startWebcam();
+                                    await gameInstance.network.startWebcam(
+                                        shouldConnectToOtherPlayers
+                                    );
                                     toast(
                                         <div className="font-semibold">
-                                            Started Webcam
+                                            Camera Started
                                         </div>
                                     );
                                 }}
@@ -184,11 +237,7 @@ const FloatingActions = ({
                             </Button>
                         </TooltipTrigger>
                         <TooltipContent>
-                            <p className="text-black">
-                                {isWebcamOn
-                                    ? "Turn off camera"
-                                    : "Turn on camera"}
-                            </p>
+                            <p className="text-black">Turn on camera</p>
                         </TooltipContent>
                     </Tooltip>
                 )}

--- a/client/src/components/ScreenShare.tsx
+++ b/client/src/components/ScreenShare.tsx
@@ -169,7 +169,7 @@ const ScreenShare = ({
                     </DialogFooter>
                 </DialogContent>
             </Dialog>
-            <Toaster position="bottom-center" closeButton />
+            <Toaster position="bottom-left" closeButton />
         </>
     );
 };

--- a/server/src/rooms/MyRoom.ts
+++ b/server/src/rooms/MyRoom.ts
@@ -62,7 +62,6 @@ export class MyRoom extends Room<MyRoomState> {
 
     private handleOfficeJoin(
         client: Client,
-        peerId: string,
         username: string,
         officeType: OfficeType
     ) {
@@ -87,13 +86,11 @@ export class MyRoom extends Room<MyRoomState> {
                 member.sessionId !== client.sessionId
             ) {
                 member.send("CONNECT_TO_WEBRTC", {
-                    peerId: client.sessionId,
+                    playerSessionId: client.sessionId,
                     username,
                 });
             }
         });
-
-        console.log("peerId: ", peerId);
 
         const allMembers: any = [];
         members.forEach((value, key) => {
@@ -167,8 +164,8 @@ export class MyRoom extends Room<MyRoomState> {
             player.anim = input.anim;
         });
 
-        this.onMessage("JOIN_MAIN_OFFICE", (client, { peerId, username }) => {
-            this.handleOfficeJoin(client, peerId, username, "MAIN");
+        this.onMessage("JOIN_MAIN_OFFICE", (client, username) => {
+            this.handleOfficeJoin(client, username, "MAIN");
         });
 
         this.onMessage("LEFT_MAIN_OFFICE", (client, username) => {
@@ -182,8 +179,8 @@ export class MyRoom extends Room<MyRoomState> {
             }
         );
 
-        this.onMessage("JOIN_EAST_OFFICE", (client, { peerId, username }) => {
-            this.handleOfficeJoin(client, peerId, username, "EAST");
+        this.onMessage("JOIN_EAST_OFFICE", (client, username) => {
+            this.handleOfficeJoin(client, username, "EAST");
         });
 
         this.onMessage("LEFT_EAST_OFFICE", (client, username) => {
@@ -197,12 +194,9 @@ export class MyRoom extends Room<MyRoomState> {
             }
         );
 
-        this.onMessage(
-            "JOIN_NORTH_1_OFFICE",
-            (client, { peerId, username }) => {
-                this.handleOfficeJoin(client, peerId, username, "NORTH_1");
-            }
-        );
+        this.onMessage("JOIN_NORTH_1_OFFICE", (client, username) => {
+            this.handleOfficeJoin(client, username, "NORTH_1");
+        });
 
         this.onMessage("LEFT_NORTH_1_OFFICE", (client, username) => {
             this.handleLeftOffice(client, username, "NORTH_1");
@@ -215,12 +209,9 @@ export class MyRoom extends Room<MyRoomState> {
             }
         );
 
-        this.onMessage(
-            "JOIN_NORTH_2_OFFICE",
-            (client, { peerId, username }) => {
-                this.handleOfficeJoin(client, peerId, username, "NORTH_2");
-            }
-        );
+        this.onMessage("JOIN_NORTH_2_OFFICE", (client, username) => {
+            this.handleOfficeJoin(client, username, "NORTH_2");
+        });
 
         this.onMessage("LEFT_NORTH_2_OFFICE", (client, username) => {
             this.handleLeftOffice(client, username, "NORTH_2");
@@ -233,8 +224,8 @@ export class MyRoom extends Room<MyRoomState> {
             }
         );
 
-        this.onMessage("JOIN_WEST_OFFICE", (client, { peerId, username }) => {
-            this.handleOfficeJoin(client, peerId, username, "WEST");
+        this.onMessage("JOIN_WEST_OFFICE", (client, username) => {
+            this.handleOfficeJoin(client, username, "WEST");
         });
 
         this.onMessage("LEFT_WEST_OFFICE", (client, username) => {
@@ -266,10 +257,38 @@ export class MyRoom extends Room<MyRoomState> {
             (client, office: OfficeType) => {
                 const { members } = this.getOfficeData(office);
                 members.forEach((username, userId) => {
+                    // preventing sending message to ourself
                     if (userId === client.sessionId) return;
+
                     this.clients
                         .getById(userId)
                         .send("USER_STOPPED_SCREEN_SHARING", client.sessionId);
+                });
+            }
+        );
+
+        this.onMessage("USER_STOPPED_WEBCAM", (client, office: OfficeType) => {
+            const { members } = this.getOfficeData(office);
+            members.forEach((username, userId) => {
+                // preventing sending message to ourself
+                if (userId === client.sessionId) return;
+
+                this.clients
+                    .getById(userId)
+                    .send("USER_STOPPED_WEBCAM", client.sessionId);
+            });
+        });
+
+        this.onMessage(
+            "CONNECT_TO_VIDEO_CALL",
+            (client, office: OfficeType) => {
+                const { members } = this.getOfficeData(office);
+                members.forEach((username, userId) => {
+                    if (userId === client.sessionId) return;
+
+                    this.clients
+                        .getById(userId)
+                        .send("CONNECT_TO_VIDEO_CALL", client.sessionId);
                 });
             }
         );


### PR DESCRIPTION
**New Feature: Disconnect from Video Calls**

Players can now disconnect from video calls while inside an office using the "Disconnect from video calls" button. Once disconnected:

- Their webcam stops.
- They can no longer see others’ video streams.
- Other players also can't see their video.

**How it works**

When a player clicks the disconnect button:

- Their webcam is stopped.
- All their active peer connections are removed.
- `playerStoppedWebcam` is triggered, which broadcasts a `USER_STOPPED_WEBCAM` message to others in the same office.
- The receiving players then run `disconnectUserForVideoCalling` to remove the disconnected player from their peer connections.

I implemented this feature pretty quickly, so the code might be a bit messy for now — sorry about that!