### PR TITLE
Cleaned-up office joining/leaving logic

### DIFF
--- a/client/src/components/Chat.tsx
+++ b/client/src/components/Chat.tsx
@@ -194,7 +194,10 @@ const Chat = () => {
                         }}
                         ref={inputRef}
                     />
-                    <button className="absolute right-6" type="submit">
+                    <button
+                        className="absolute right-6 cursor-pointer"
+                        type="submit"
+                    >
                         <SentIcon />
                     </button>
                 </form>

--- a/client/src/game/scenes/GameScene.ts
+++ b/client/src/game/scenes/GameScene.ts
@@ -5,6 +5,11 @@ export class GameScene extends Phaser.Scene {
     mapLayer: Phaser.Tilemaps.TilemapLayer;
     map!: Phaser.Tilemaps.Tilemap;
     network: Network;
+    currentPlayer: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody;
+    cursorKeys: Phaser.Types.Input.Keyboard.CursorKeys;
+    otherPlayers: {
+        [sessionId: string]: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody;
+    } = {};
 
     constructor() {
         super({ key: "GameScene" });
@@ -157,7 +162,6 @@ export class GameScene extends Phaser.Scene {
             }
         });
 
-        this.network.handleOfficeMessages();
         this.network.handleServerMessages();
     }
 

--- a/client/src/game/scenes/GameScene.ts
+++ b/client/src/game/scenes/GameScene.ts
@@ -5,11 +5,6 @@ export class GameScene extends Phaser.Scene {
     mapLayer: Phaser.Tilemaps.TilemapLayer;
     map!: Phaser.Tilemaps.Tilemap;
     network: Network;
-    currentPlayer: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody;
-    cursorKeys: Phaser.Types.Input.Keyboard.CursorKeys;
-    otherPlayers: {
-        [sessionId: string]: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody;
-    } = {};
 
     constructor() {
         super({ key: "GameScene" });

--- a/client/src/game/scenes/OfficeManager.ts
+++ b/client/src/game/scenes/OfficeManager.ts
@@ -1,0 +1,86 @@
+import Phaser from "phaser";
+
+type OfficeName =
+    | "mainOffice"
+    | "eastOffice"
+    | "westOffice"
+    | "northOffice1"
+    | "northOffice2";
+
+type OfficeZone = {
+    name: OfficeName;
+    rect: Phaser.Geom.Rectangle;
+};
+
+export class OfficeManager {
+    private offices: OfficeZone[] = [];
+    private currentOffice: OfficeName | null = null;
+    private lastRect: Phaser.Geom.Rectangle | null = null;
+
+    constructor() {
+        this.offices = [
+            {
+                name: "mainOffice",
+                rect: new Phaser.Geom.Rectangle(799.85, 608.02, 799.85, 512.02),
+            },
+            {
+                name: "eastOffice",
+                rect: new Phaser.Geom.Rectangle(63.96, 351.94, 384.12, 768.09),
+            },
+            {
+                name: "westOffice",
+                rect: new Phaser.Geom.Rectangle(1920.0, 608.25, 448.13, 544.0),
+            },
+            {
+                name: "northOffice1",
+                rect: new Phaser.Geom.Rectangle(927.85, 156.61, 512.09, 259.42),
+            },
+            {
+                name: "northOffice2",
+                rect: new Phaser.Geom.Rectangle(
+                    1471.97,
+                    156.61,
+                    512.09,
+                    259.42
+                ),
+            },
+        ];
+    }
+
+    /**
+     * Check & Update player's current office.
+     *
+     * @param x player's x position
+     * @param y player's y position
+     * @returns name of the current office or null if player is not in any office
+     */
+    public update(x: number, y: number): OfficeName | null {
+        // Check last office first
+        if (
+            this.lastRect &&
+            Phaser.Geom.Rectangle.Contains(this.lastRect, x, y)
+        ) {
+            return this.currentOffice;
+        }
+
+        for (const office of this.offices) {
+            if (Phaser.Geom.Rectangle.Contains(office.rect, x, y)) {
+                if (office.name !== this.currentOffice) {
+                    // user joined new office
+                    this.currentOffice = office.name;
+                    this.lastRect = office.rect;
+                    return this.currentOffice;
+                }
+                return this.currentOffice; // Already in office
+            }
+        }
+
+        // If not in any office
+        if (this.currentOffice !== null) {
+            this.currentOffice = null;
+            this.lastRect = null;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
cleaned up joining & exiting office logic, hopefully didn't introduced any new bug :p

replaced office joining messages ( `JOIN_MAIN_OFFICE`, `JOIN_EAST_OFFICE`, etc ) with `JOIN_OFFICE` 

similarly replaced office leaving messages ( `LEFT_MAIN_OFFICE`, `LEFT_EAST_OFFICE`, etc ) with `LEAVE_OFFICE`

removed `handleOfficeChatMessages` function which was used to handle office specific messages and replaced it with `NEW_OFFICE_MESSAGE`


with the removal of `handleOfficeChatMessages`, we also didn't required `prevOffice` instance variable anymore, so removed it also.

Created `OfficeManager.ts` to handle entering/exiting office logic more efficiently, also added some optimization so if user is already in an office no need to further check more, just early return it.


