### PR TITLE
fix: prevent new joinee's webcam from showing after user disconnects from video calls

### DIFF
--- a/client/src/app/features/webRtc/webcamSlice.ts
+++ b/client/src/app/features/webRtc/webcamSlice.ts
@@ -7,6 +7,7 @@ interface InitialState {
     peerStreams: Map<string, { call: MediaConnection; stream: MediaStream }>;
     isWebcamOn: boolean;
     isMicOn: boolean;
+    isDisconnectedFromVideoCalls: boolean;
 }
 
 const initialState: InitialState = {
@@ -14,6 +15,7 @@ const initialState: InitialState = {
     peerStreams: new Map(),
     isWebcamOn: false,
     isMicOn: false,
+    isDisconnectedFromVideoCalls: false,
 };
 
 const webcamSlice = createSlice({
@@ -25,6 +27,7 @@ const webcamSlice = createSlice({
             state.myWebcamStream = action.payload;
             state.isWebcamOn = true;
             state.isMicOn = true;
+            state.isDisconnectedFromVideoCalls = false;
         },
         toggleWebcam: (state) => {
             state.myWebcamStream.getVideoTracks()[0].enabled =
@@ -102,6 +105,8 @@ const webcamSlice = createSlice({
             });
 
             state.peerStreams.clear();
+
+            state.isDisconnectedFromVideoCalls = true;
         },
     },
 });

--- a/client/src/components/VideoCall.tsx
+++ b/client/src/components/VideoCall.tsx
@@ -6,6 +6,12 @@ const VideoCall = () => {
         (state) => state.webcam.myWebcamStream
     );
     const peerStreams = useAppSelector((state) => state.webcam.peerStreams);
+    const isDisconnectedFromVideoCalls = useAppSelector(
+        (state) => state.webcam.isDisconnectedFromVideoCalls
+    );
+
+    // if user clicked on "Disconnect from video calls" then do not show any webcams.
+    if (isDisconnectedFromVideoCalls) return;
 
     return (
         <div className="absolute left-[35px] top-[10px] h-screen flex flex-col flex-wrap gap-2">
@@ -22,6 +28,7 @@ const VideoCall = () => {
                     <VideoPlayer
                         stream={value.stream}
                         className="w-48 border-2"
+                        key={key}
                     />
                 );
             })}


### PR DESCRIPTION
Previously, if a user inside an office clicked "Disconnect from video calls", they would stop seeing others' webcams as expected. However, if a new user joined the office after that and enabled their webcam, their video was still shown to the disconnected user.

This fix ensures that once a user has opted out of video calls, they will not see any new incoming webcams, maintaining the intended behavior.