### PR TITLE
Added support for proximity chat

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -15,19 +15,22 @@ function App() {
     return (
         <>
             {!roomJoined && <RoomSelection />}
-            {roomJoined && <Chat />}
-            <AnimatePresence mode="wait">
-                {showOfficeChat && (
-                    <FloatingActions
-                        key="floating-buttons"
-                        setScreenDialogOpen={setScreenDialogOpen}
-                    />
-                )}
-            </AnimatePresence>
+            {roomJoined && (
+                <>
+                    <Chat />
+                    <VideoCall />
+                    <AnimatePresence mode="wait">
+                        <FloatingActions
+                            key="floating-buttons"
+                            isInsideOffice={showOfficeChat}
+                            setScreenDialogOpen={setScreenDialogOpen}
+                        />
+                    </AnimatePresence>
+                </>
+            )}
 
             {showOfficeChat && (
                 <>
-                    <VideoCall />
                     <ScreenShare
                         screenDialogOpen={screenDialogOpen}
                         setScreenDialogOpen={setScreenDialogOpen}

--- a/client/src/app/features/chat/chatSlice.ts
+++ b/client/src/app/features/chat/chatSlice.ts
@@ -23,13 +23,10 @@ const chatSlice = createSlice({
             state.officeChatMessages.push(action.payload);
         },
         addOfficeChat: (state, action: PayloadAction<ChatMessageType[]>) => {
-            console.log("action: ", action.payload);
             state.officeChatMessages = [...action.payload];
-            console.log("new chatMessage: ", state.officeChatMessages);
         },
         clearOfficeChat: (state) => {
             state.officeChatMessages = [];
-            console.log("chat cleared: ", state.officeChatMessages);
         },
         setShowOfficeChat: (state, action: PayloadAction<boolean>) => {
             state.showOfficeChat = action.payload;
@@ -43,9 +40,7 @@ const chatSlice = createSlice({
             state.globalChatMessages.push(action.payload);
         },
         addGlobalChat: (state, action: PayloadAction<ChatMessageType[]>) => {
-            console.log("action: ", action.payload);
             state.globalChatMessages = [...action.payload];
-            console.log("new chatMessage: ", state.globalChatMessages);
         },
     },
 });

--- a/client/src/app/features/webRtc/webcamSlice.ts
+++ b/client/src/app/features/webRtc/webcamSlice.ts
@@ -66,8 +66,10 @@ const webcamSlice = createSlice({
             const sanitizedId = sanitizeUserIdForVideoCalling(action.payload);
             const peer = state.peerStreams.get(sanitizedId);
 
-            peer.call.close();
-            state.peerStreams.delete(sanitizedId);
+            if (peer) {
+                peer.call.close();
+                state.peerStreams.delete(sanitizedId);
+            }
         },
         /**
          * Disconnect all the connected peers with current player.
@@ -75,13 +77,6 @@ const webcamSlice = createSlice({
          * Used when player leaves an office.
          */
         removeAllPeerConnectionsForVideoCalling: (state) => {
-            if (state.myWebcamStream) {
-                state.myWebcamStream.getVideoTracks()[0].enabled = false;
-                state.myWebcamStream.getAudioTracks()[0].enabled = false;
-                state.isWebcamOn = false;
-                state.isMicOn = false;
-            }
-
             state.peerStreams.forEach((peer) => {
                 peer.call.close();
             });

--- a/client/src/app/features/webRtc/webcamSlice.ts
+++ b/client/src/app/features/webRtc/webcamSlice.ts
@@ -90,6 +90,9 @@ const webcamSlice = createSlice({
          */
         disconnectFromVideoCall: (state) => {
             if (state.myWebcamStream) {
+                const tracks = state.myWebcamStream.getTracks();
+                tracks.forEach((track) => track.stop());
+
                 state.myWebcamStream = null;
                 state.isWebcamOn = false;
                 state.isMicOn = false;

--- a/client/src/components/FloatingActions.tsx
+++ b/client/src/components/FloatingActions.tsx
@@ -23,8 +23,10 @@ import { toast } from "sonner";
 import { useState } from "react";
 
 const FloatingActions = ({
+    isInsideOffice,
     setScreenDialogOpen,
 }: {
+    isInsideOffice: boolean;
     setScreenDialogOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }) => {
     const [shouldConnectToOtherPlayers, setShouldConnectToOtherPlayers] =
@@ -50,22 +52,24 @@ const FloatingActions = ({
         >
             <TooltipProvider>
                 {/* Screen Sharing */}
-                <Tooltip>
-                    <TooltipTrigger asChild>
-                        <Button
-                            variant="outline"
-                            className="cursor-pointer "
-                            onClick={() => {
-                                setScreenDialogOpen(true);
-                            }}
-                        >
-                            <ScreenShare />
-                        </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                        <p className="text-black">Screen Sharing</p>
-                    </TooltipContent>
-                </Tooltip>
+                {isInsideOffice && (
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <Button
+                                variant="outline"
+                                className="cursor-pointer "
+                                onClick={() => {
+                                    setScreenDialogOpen(true);
+                                }}
+                            >
+                                <ScreenShare />
+                            </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                            <p className="text-black">Screen Sharing</p>
+                        </TooltipContent>
+                    </Tooltip>
+                )}
 
                 {myWebcamStream ? (
                     // Player has given access to his webcam

--- a/client/src/components/FloatingActions.tsx
+++ b/client/src/components/FloatingActions.tsx
@@ -34,8 +34,6 @@ const FloatingActions = ({
     const myWebcamStream = useAppSelector(
         (state) => state.webcam.myWebcamStream
     );
-    const isWebcamOn = useAppSelector((state) => state.webcam.isWebcamOn);
-    const isMicOn = useAppSelector((state) => state.webcam.isMicOn);
 
     return (
         <motion.div
@@ -73,140 +71,11 @@ const FloatingActions = ({
 
                 {myWebcamStream ? (
                     // Player has given access to his webcam
-                    <>
-                        {/* Webcam */}
-                        <Tooltip>
-                            <TooltipTrigger asChild>
-                                <Button
-                                    variant="outline"
-                                    className="cursor-pointer transition-all ease-in-out"
-                                    onClick={() => {
-                                        store.dispatch(toggleWebcam());
-                                    }}
-                                >
-                                    <AnimatePresence
-                                        mode="wait"
-                                        initial={false}
-                                    >
-                                        {isWebcamOn ? (
-                                            <motion.div
-                                                key="webcam"
-                                                initial={{ opacity: 0 }}
-                                                animate={{ opacity: 1 }}
-                                                exit={{ opacity: 0 }}
-                                                transition={{ duration: 0.2 }}
-                                            >
-                                                <Camera />
-                                            </motion.div>
-                                        ) : (
-                                            <motion.div
-                                                key="mic-off"
-                                                initial={{ opacity: 0 }}
-                                                animate={{ opacity: 1 }}
-                                                exit={{ opacity: 0 }}
-                                                transition={{ duration: 0.2 }}
-                                            >
-                                                <CameraOff />
-                                            </motion.div>
-                                        )}
-                                    </AnimatePresence>
-                                </Button>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                                <p className="text-black">
-                                    {isWebcamOn
-                                        ? "Turn off camera"
-                                        : "Turn on camera"}
-                                </p>
-                            </TooltipContent>
-                        </Tooltip>
-
-                        {/* Mic */}
-                        <Tooltip>
-                            <TooltipTrigger asChild>
-                                <Button
-                                    variant="outline"
-                                    className="cursor-pointer transition-all ease-in-out"
-                                    onClick={() => {
-                                        store.dispatch(toggleMic());
-                                    }}
-                                >
-                                    <AnimatePresence
-                                        mode="wait"
-                                        initial={false}
-                                    >
-                                        {isMicOn ? (
-                                            <motion.div
-                                                key="mic"
-                                                initial={{ opacity: 0 }}
-                                                animate={{ opacity: 1 }}
-                                                exit={{ opacity: 0 }}
-                                                transition={{ duration: 0.2 }}
-                                            >
-                                                <Mic />
-                                            </motion.div>
-                                        ) : (
-                                            <motion.div
-                                                key="mic-off"
-                                                initial={{ opacity: 0 }}
-                                                animate={{ opacity: 1 }}
-                                                exit={{ opacity: 0 }}
-                                                transition={{ duration: 0.2 }}
-                                            >
-                                                <MicOff />
-                                            </motion.div>
-                                        )}
-                                    </AnimatePresence>
-                                </Button>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                                <p className="text-black">
-                                    {isMicOn ? "Turn off mic" : "Turn on mic"}
-                                </p>
-                            </TooltipContent>
-                        </Tooltip>
-
-                        {/* Disconnect */}
-                        <Tooltip>
-                            <TooltipTrigger asChild>
-                                <Button
-                                    variant="destructive"
-                                    className="cursor-pointer transition-all ease-in-out"
-                                    onClick={() => {
-                                        const gameInstance = phaserGame.scene
-                                            .keys.GameScene as GameScene;
-                                        gameInstance.network.playerStoppedWebcam();
-                                        setShouldConnectToOtherPlayers(true);
-                                        toast(
-                                            <div className="font-semibold">
-                                                Disconnected from video calls
-                                            </div>
-                                        );
-                                    }}
-                                >
-                                    <AnimatePresence
-                                        mode="wait"
-                                        initial={false}
-                                    >
-                                        <motion.div
-                                            key="mic-off"
-                                            initial={{ opacity: 0 }}
-                                            animate={{ opacity: 1 }}
-                                            exit={{ opacity: 0 }}
-                                            transition={{ duration: 0.2 }}
-                                        >
-                                            <PhoneOff />
-                                        </motion.div>
-                                    </AnimatePresence>
-                                </Button>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                                <p className="text-black">
-                                    Disconnect From Video Calls
-                                </p>
-                            </TooltipContent>
-                        </Tooltip>
-                    </>
+                    <WebcamButtons
+                        setShouldConnectToOtherPlayers={
+                            setShouldConnectToOtherPlayers
+                        }
+                    />
                 ) : (
                     // Player has not given access to his webcam
                     <Tooltip>
@@ -247,6 +116,145 @@ const FloatingActions = ({
                 )}
             </TooltipProvider>
         </motion.div>
+    );
+};
+
+export const WebcamButtons = ({
+    shouldShowDisconnectButton = true,
+    setShouldConnectToOtherPlayers,
+}: {
+    shouldShowDisconnectButton?: boolean;
+    setShouldConnectToOtherPlayers?: (x: boolean) => void;
+}) => {
+    const isWebcamOn = useAppSelector((state) => state.webcam.isWebcamOn);
+    const isMicOn = useAppSelector((state) => state.webcam.isMicOn);
+
+    return (
+        <>
+            {/* Webcam */}
+            <Tooltip>
+                <TooltipTrigger asChild>
+                    <Button
+                        variant="outline"
+                        className="cursor-pointer transition-all ease-in-out"
+                        onClick={() => {
+                            store.dispatch(toggleWebcam());
+                        }}
+                    >
+                        <AnimatePresence mode="wait" initial={false}>
+                            {isWebcamOn ? (
+                                <motion.div
+                                    key="webcam"
+                                    initial={{ opacity: 0 }}
+                                    animate={{ opacity: 1 }}
+                                    exit={{ opacity: 0 }}
+                                    transition={{ duration: 0.2 }}
+                                >
+                                    <Camera />
+                                </motion.div>
+                            ) : (
+                                <motion.div
+                                    key="mic-off"
+                                    initial={{ opacity: 0 }}
+                                    animate={{ opacity: 1 }}
+                                    exit={{ opacity: 0 }}
+                                    transition={{ duration: 0.2 }}
+                                >
+                                    <CameraOff />
+                                </motion.div>
+                            )}
+                        </AnimatePresence>
+                    </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                    <p className="text-black">
+                        {isWebcamOn ? "Turn off camera" : "Turn on camera"}
+                    </p>
+                </TooltipContent>
+            </Tooltip>
+
+            {/* Mic */}
+            <Tooltip>
+                <TooltipTrigger asChild>
+                    <Button
+                        variant="outline"
+                        className="cursor-pointer transition-all ease-in-out"
+                        onClick={() => {
+                            store.dispatch(toggleMic());
+                        }}
+                    >
+                        <AnimatePresence mode="wait" initial={false}>
+                            {isMicOn ? (
+                                <motion.div
+                                    key="mic"
+                                    initial={{ opacity: 0 }}
+                                    animate={{ opacity: 1 }}
+                                    exit={{ opacity: 0 }}
+                                    transition={{ duration: 0.2 }}
+                                >
+                                    <Mic />
+                                </motion.div>
+                            ) : (
+                                <motion.div
+                                    key="mic-off"
+                                    initial={{ opacity: 0 }}
+                                    animate={{ opacity: 1 }}
+                                    exit={{ opacity: 0 }}
+                                    transition={{ duration: 0.2 }}
+                                >
+                                    <MicOff />
+                                </motion.div>
+                            )}
+                        </AnimatePresence>
+                    </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                    <p className="text-black">
+                        {isMicOn ? "Turn off mic" : "Turn on mic"}
+                    </p>
+                </TooltipContent>
+            </Tooltip>
+
+            {/* Disconnect */}
+            {shouldShowDisconnectButton && (
+                <Tooltip>
+                    <TooltipTrigger asChild>
+                        <Button
+                            variant="destructive"
+                            className="cursor-pointer transition-all ease-in-out"
+                            onClick={() => {
+                                const gameInstance = phaserGame.scene.keys
+                                    .GameScene as GameScene;
+                                gameInstance.network.playerStoppedWebcam();
+                                setShouldConnectToOtherPlayers(true);
+                                toast(
+                                    <div className="font-semibold">
+                                        Disconnected from video calls
+                                    </div>
+                                );
+                            }}
+                        >
+                            <AnimatePresence mode="wait" initial={false}>
+                                <motion.div
+                                    key="mic-off"
+                                    initial={{ opacity: 0 }}
+                                    animate={{ opacity: 1 }}
+                                    exit={{ opacity: 0 }}
+                                    transition={{ duration: 0.2 }}
+                                >
+                                    <PhoneOff />
+                                </motion.div>
+                            </AnimatePresence>
+                        </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                        <p className="text-black">
+                            Disconnect From Video Calls
+                        </p>
+                    </TooltipContent>
+                </Tooltip>
+            )}
+        </>
     );
 };
 

--- a/client/src/components/RoomSelection/CharacterCarousel.tsx
+++ b/client/src/components/RoomSelection/CharacterCarousel.tsx
@@ -1,0 +1,62 @@
+import {
+    Carousel,
+    CarouselContent,
+    CarouselItem,
+    CarouselNext,
+    CarouselPrevious,
+} from "../ui/carousel";
+
+const CharacterCarousel = ({ setApi }: { setApi: () => void }) => {
+    return (
+        <div className="grid place-items-center gap-3">
+            <Carousel setApi={setApi} opts={{ loop: true }} className="w-[60%]">
+                <CarouselContent>
+                    <CarouselItem>
+                        <div className="flex items-center justify-center bg-zinc-200 p-3 rounded-md">
+                            <img
+                                src="assets/characters/single/Nancy_idle_anim_20.png"
+                                alt="Nancy"
+                                width={50}
+                                height={50}
+                            />
+                        </div>
+                    </CarouselItem>
+                    <CarouselItem>
+                        <div className="flex items-center justify-center bg-zinc-200 p-3 rounded-md">
+                            <img
+                                src="assets/characters/single/Ash_idle_anim_20.png"
+                                alt="Ash"
+                                width={50}
+                                height={50}
+                            />
+                        </div>
+                    </CarouselItem>
+                    <CarouselItem>
+                        <div className="flex items-center justify-center bg-zinc-200 p-3 rounded-md">
+                            <img
+                                src="assets/characters/single/Lucy_idle_anim_20.png"
+                                alt="Lucy"
+                                width={50}
+                                height={50}
+                            />
+                        </div>
+                    </CarouselItem>
+                    <CarouselItem>
+                        <div className="flex items-center justify-center bg-zinc-200 p-3 rounded-md">
+                            <img
+                                src="assets/characters/single/Adam_idle_anim_20.png"
+                                alt="Adam"
+                                width={50}
+                                height={50}
+                            />
+                        </div>
+                    </CarouselItem>
+                </CarouselContent>
+                <CarouselPrevious className="cursor-pointer" />
+                <CarouselNext className="cursor-pointer" />
+            </Carousel>
+        </div>
+    );
+};
+
+export default CharacterCarousel;

--- a/client/src/components/RoomSelection/CreateCustomRoom.tsx
+++ b/client/src/components/RoomSelection/CreateCustomRoom.tsx
@@ -10,46 +10,37 @@ import {
     CardHeader,
     CardTitle,
 } from "../ui/card";
-import {
-    Carousel,
-    CarouselApi,
-    CarouselContent,
-    CarouselItem,
-    CarouselNext,
-    CarouselPrevious,
-} from "../ui/carousel";
 import phaserGame from "../../game/main";
 import { ArrowLeft, LoaderIcon } from "lucide-react";
 import { useAppSelector } from "../../app/hooks";
+import { VideoPlayer } from "../VideoPlayer";
+import { WebcamButtons } from "../FloatingActions";
+import videoCalling from "../../game/service/VideoCalling";
+import store from "../../app/store";
+import { disconnectFromVideoCall } from "../../app/features/webRtc/webcamSlice";
+import CharacterCarousel from "./CharacterCarousel";
 
 const CreateCustomRoom = ({
+    setCarouselApi,
+    getSelectedCharacter,
     setShowCreateOrJoinCustomRoom,
     setShowCreateRoom,
 }: {
+    setCarouselApi: () => void;
+    getSelectedCharacter: () => "nancy" | "ash" | "lucy" | "adam";
     setShowCreateOrJoinCustomRoom: React.Dispatch<
         React.SetStateAction<boolean>
     >;
     setShowCreateRoom: React.Dispatch<React.SetStateAction<boolean>>;
 }) => {
     const bootstrap = phaserGame.scene.keys.bootstrap as Bootstrap;
-    const [api, setApi] = useState<CarouselApi>();
     const [username, setUsername] = useState<string>();
     const [roomName, setRoomName] = useState<string>();
     const [password, setPassword] = useState<string>(null);
     const isLoading = useAppSelector((state) => state.room.isLoading);
-
-    const getSelectedCharacter = () => {
-        switch (api.selectedScrollSnap()) {
-            case 0:
-                return "nancy";
-            case 1:
-                return "ash";
-            case 2:
-                return "lucy";
-            case 3:
-                return "adam";
-        }
-    };
+    const myWebcamStream = useAppSelector(
+        (state) => state.webcam.myWebcamStream
+    );
 
     const handleRoomCreation = (e) => {
         e.preventDefault();
@@ -68,7 +59,7 @@ const CreateCustomRoom = ({
     };
 
     return (
-        <Card className="w-full max-w-2xl">
+        <Card>
             <CardHeader>
                 <CardTitle className="relative text-2xl text-center">
                     <ArrowLeft
@@ -76,6 +67,10 @@ const CreateCustomRoom = ({
                         onClick={() => {
                             setShowCreateOrJoinCustomRoom(true);
                             setShowCreateRoom(false);
+                            {
+                                myWebcamStream &&
+                                    store.dispatch(disconnectFromVideoCall());
+                            }
                         }}
                     />
                     Create Custom Room
@@ -84,107 +79,84 @@ const CreateCustomRoom = ({
                     Custom rooms can be created with or without password!
                 </CardDescription>
             </CardHeader>
-            <CardContent className="grid grid-cols-2 gap-4">
-                <div className="grid place-items-center">
-                    <Carousel
-                        setApi={setApi}
-                        opts={{ loop: true }}
-                        className="w-[70%]"
-                    >
-                        <CarouselContent>
-                            <CarouselItem>
-                                <div className="flex items-center justify-center bg-zinc-200 p-3 rounded-md">
-                                    <img
-                                        src="assets/characters/single/Nancy_idle_anim_20.png"
-                                        alt="Nancy"
-                                        width={100}
-                                        height={100}
-                                    />
-                                </div>
-                            </CarouselItem>
-                            <CarouselItem>
-                                <div className="flex items-center justify-center bg-zinc-200 p-3 rounded-md">
-                                    <img
-                                        src="assets/characters/single/Ash_idle_anim_20.png"
-                                        alt="Ash"
-                                        width={100}
-                                        height={100}
-                                    />
-                                </div>
-                            </CarouselItem>
-                            <CarouselItem>
-                                <div className="flex items-center justify-center bg-zinc-200 p-3 rounded-md">
-                                    <img
-                                        src="assets/characters/single/Lucy_idle_anim_20.png"
-                                        alt="Lucy"
-                                        width={100}
-                                        height={100}
-                                    />
-                                </div>
-                            </CarouselItem>
-                            <CarouselItem>
-                                <div className="flex items-center justify-center bg-zinc-200 p-3 rounded-md">
-                                    <img
-                                        src="assets/characters/single/Adam_idle_anim_20.png"
-                                        alt="Adam"
-                                        width={100}
-                                        height={100}
-                                    />
-                                </div>
-                            </CarouselItem>
-                        </CarouselContent>
-                        <CarouselPrevious className="cursor-pointer" />
-                        <CarouselNext className="cursor-pointer" />
-                    </Carousel>
+            <CardContent className="flex gap-4 items-center">
+                {myWebcamStream && (
+                    <Card className="flex items-center justify-center">
+                        <CardContent>
+                            <VideoPlayer
+                                stream={myWebcamStream}
+                                className="w-48"
+                                muted
+                            />
+                        </CardContent>
+                    </Card>
+                )}
+                <div>
+                    <CharacterCarousel setApi={setCarouselApi} />
+                    <form className="grid gap-2" onSubmit={handleRoomCreation}>
+                        <Label htmlFor="username">Username</Label>
+                        <Input
+                            id="username"
+                            type="text"
+                            placeholder="Username"
+                            required
+                            value={username}
+                            onChange={(e) => {
+                                setUsername(e.target.value);
+                            }}
+                        />
+                        <Label htmlFor="roomName">Room name</Label>
+                        <Input
+                            id="roomName"
+                            type="text"
+                            placeholder="Nancy's Room"
+                            required
+                            value={roomName}
+                            onChange={(e) => {
+                                setRoomName(e.target.value);
+                            }}
+                        />
+                        <Label htmlFor="password">Password</Label>
+                        <Input
+                            id="password"
+                            type="password"
+                            placeholder="Passoword ( Optional )"
+                            value={password}
+                            onChange={(e) => {
+                                setPassword(e.target.value);
+                            }}
+                        />
+                        <Button
+                            className="w-full cursor-pointer mt-2"
+                            type="submit"
+                            disabled={isLoading}
+                        >
+                            {isLoading ? (
+                                <>
+                                    Creating Room{" "}
+                                    <LoaderIcon className="ml-2 h-4 w-4 animate-spin" />
+                                </>
+                            ) : (
+                                "Create Room"
+                            )}
+                        </Button>
+                    </form>
+                    {!myWebcamStream ? (
+                        <Button
+                            className="w-full cursor-pointer mt-2"
+                            variant="outline"
+                            onClick={async () => {
+                                await videoCalling.getUserMedia();
+                            }}
+                        >
+                            Start Webcam
+                        </Button>
+                    ) : (
+                        <div className="flex gap-3 items-center justify-center mt-2">
+                            <WebcamButtons shouldShowDisconnectButton={false} />
+                        </div>
+                    )}
                 </div>
-                <form className="grid gap-2" onSubmit={handleRoomCreation}>
-                    <Label htmlFor="username">Username</Label>
-                    <Input
-                        id="username"
-                        type="text"
-                        placeholder="Username"
-                        required
-                        value={username}
-                        onChange={(e) => {
-                            setUsername(e.target.value);
-                        }}
-                    />
-                    <Label htmlFor="roomName">Room name</Label>
-                    <Input
-                        id="roomName"
-                        type="text"
-                        placeholder="Nancy's Room"
-                        required
-                        value={roomName}
-                        onChange={(e) => {
-                            setRoomName(e.target.value);
-                        }}
-                    />
-                    <Label htmlFor="password">Password</Label>
-                    <Input
-                        id="password"
-                        type="password"
-                        placeholder="Passoword ( Optional )"
-                        value={password}
-                        onChange={(e) => {
-                            setPassword(e.target.value);
-                        }}
-                    />
-                    <Button
-                        className="w-full cursor-pointer mt-2"
-                        type="submit"
-                        disabled={isLoading}
-                    >
-                        {isLoading ? (
-                            <>
-                                Creating Room{" "}
-                                <LoaderIcon className="ml-2 h-4 w-4 animate-spin" />
-                            </>
-                        ) : (
-                            "Create Room"
-                        )}
-                    </Button>
-                </form>
             </CardContent>
         </Card>
     );

--- a/client/src/components/RoomSelection/JoinCustomRoom.tsx
+++ b/client/src/components/RoomSelection/JoinCustomRoom.tsx
@@ -5,50 +5,41 @@ import { Button } from "../ui/button";
 import { ArrowLeft, LoaderIcon } from "lucide-react";
 import { useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
-import {
-    Carousel,
-    CarouselApi,
-    CarouselContent,
-    CarouselItem,
-    CarouselNext,
-    CarouselPrevious,
-} from "../ui/carousel";
 import phaserGame from "../../game/main";
 import { useAppSelector } from "../../app/hooks";
+import CharacterCarousel from "./CharacterCarousel";
+import { VideoPlayer } from "../VideoPlayer";
+import videoCalling from "../../game/service/VideoCalling";
+import { WebcamButtons } from "../FloatingActions";
+import store from "../../app/store";
+import { disconnectFromVideoCall } from "../../app/features/webRtc/webcamSlice";
 
 const JoinCustomRoom = ({
     roomName,
     roomId,
     roomHasPassowrd,
+    setCarouselApi,
+    getSelectedCharacter,
     setShowCreateOrJoinCustomRoom,
     setShowJoinRoom,
 }: {
     roomName: string;
     roomId: string;
     roomHasPassowrd: boolean;
+    setCarouselApi: () => void;
+    getSelectedCharacter: () => "nancy" | "ash" | "lucy" | "adam";
     setShowCreateOrJoinCustomRoom: React.Dispatch<
         React.SetStateAction<boolean>
     >;
     setShowJoinRoom: React.Dispatch<React.SetStateAction<boolean>>;
 }) => {
     const bootstrap = phaserGame.scene.keys.bootstrap as Bootstrap;
-    const [api, setApi] = useState<CarouselApi>();
     const [username, setUsername] = useState<string>();
     const [password, setPassword] = useState<string>(null);
     const isLoading = useAppSelector((state) => state.room.isLoading);
-
-    const getSelectedCharacter = () => {
-        switch (api.selectedScrollSnap()) {
-            case 0:
-                return "nancy";
-            case 1:
-                return "ash";
-            case 2:
-                return "lucy";
-            case 3:
-                return "adam";
-        }
-    };
+    const myWebcamStream = useAppSelector(
+        (state) => state.webcam.myWebcamStream
+    );
 
     const handleRoomJoin = (e) => {
         e.preventDefault();
@@ -60,8 +51,9 @@ const JoinCustomRoom = ({
                 bootstrap.launchGame();
             });
     };
+
     return (
-        <Card className="w-full max-w-2xl">
+        <Card>
             <CardHeader>
                 <CardTitle className="relative text-2xl text-center">
                     <ArrowLeft
@@ -69,103 +61,84 @@ const JoinCustomRoom = ({
                         onClick={() => {
                             setShowCreateOrJoinCustomRoom(true);
                             setShowJoinRoom(false);
+                            {
+                                myWebcamStream &&
+                                    store.dispatch(disconnectFromVideoCall());
+                            }
                         }}
                     />
                     Join {roomName}
                 </CardTitle>
             </CardHeader>
-            <CardContent className="grid grid-cols-2 gap-4">
-                <div className="grid place-items-center">
-                    <Carousel
-                        setApi={setApi}
-                        opts={{ loop: true }}
-                        className="w-[70%]"
-                    >
-                        <CarouselContent>
-                            <CarouselItem>
-                                <div className="flex items-center justify-center bg-zinc-200 p-3 rounded-md">
-                                    <img
-                                        src="assets/characters/single/Nancy_idle_anim_20.png"
-                                        alt="Nancy"
-                                        width={100}
-                                        height={100}
-                                    />
-                                </div>
-                            </CarouselItem>
-                            <CarouselItem>
-                                <div className="flex items-center justify-center bg-zinc-200 p-3 rounded-md">
-                                    <img
-                                        src="assets/characters/single/Ash_idle_anim_20.png"
-                                        alt="Ash"
-                                        width={100}
-                                        height={100}
-                                    />
-                                </div>
-                            </CarouselItem>
-                            <CarouselItem>
-                                <div className="flex items-center justify-center bg-zinc-200 p-3 rounded-md">
-                                    <img
-                                        src="assets/characters/single/Lucy_idle_anim_20.png"
-                                        alt="Lucy"
-                                        width={100}
-                                        height={100}
-                                    />
-                                </div>
-                            </CarouselItem>
-                            <CarouselItem>
-                                <div className="flex items-center justify-center bg-zinc-200 p-3 rounded-md">
-                                    <img
-                                        src="assets/characters/single/Adam_idle_anim_20.png"
-                                        alt="Adam"
-                                        width={100}
-                                        height={100}
-                                    />
-                                </div>
-                            </CarouselItem>
-                        </CarouselContent>
-                        <CarouselPrevious className="cursor-pointer" />
-                        <CarouselNext className="cursor-pointer" />
-                    </Carousel>
-                </div>
-                <form className="grid gap-2" onSubmit={handleRoomJoin}>
-                    <Label htmlFor="username">Username</Label>
-                    <Input
-                        id="username"
-                        type="text"
-                        required
-                        value={username}
-                        onChange={(e) => {
-                            setUsername(e.target.value);
-                        }}
-                    />
-                    {roomHasPassowrd && (
-                        <>
-                            <Label htmlFor="password">Password</Label>
-                            <Input
-                                id="password"
-                                type="password"
-                                value={password}
-                                onChange={(e) => {
-                                    setPassword(e.target.value);
-                                }}
+            <CardContent className="flex gap-4 items-center">
+                {myWebcamStream && (
+                    <Card className="flex items-center justify-center">
+                        <CardContent>
+                            <VideoPlayer
+                                stream={myWebcamStream}
+                                className="w-48"
+                                muted
                             />
-                        </>
-                    )}
-                    <Button
-                        className="w-full cursor-pointer mt-2"
-                        type="submit"
-                        disabled={isLoading}
-                    >
-                        {isLoading ? (
+                        </CardContent>
+                    </Card>
+                )}
+                <div>
+                    <CharacterCarousel setApi={setCarouselApi} />
+                    <form className="grid gap-2" onSubmit={handleRoomJoin}>
+                        <Label htmlFor="username">Username</Label>
+                        <Input
+                            id="username"
+                            type="text"
+                            required
+                            value={username}
+                            onChange={(e) => {
+                                setUsername(e.target.value);
+                            }}
+                        />
+                        {roomHasPassowrd && (
                             <>
-                                Joining Room{" "}
-                                <LoaderIcon className="ml-2 h-4 w-4 animate-spin" />
+                                <Label htmlFor="password">Password</Label>
+                                <Input
+                                    id="password"
+                                    type="password"
+                                    value={password}
+                                    onChange={(e) => {
+                                        setPassword(e.target.value);
+                                    }}
+                                />
                             </>
-                        ) : (
-                            "Join Room"
                         )}
-                    </Button>
-                </form>
+                        <Button
+                            className="w-full cursor-pointer mt-2"
+                            type="submit"
+                            disabled={isLoading}
+                        >
+                            {isLoading ? (
+                                <>
+                                    Joining Room{" "}
+                                    <LoaderIcon className="ml-2 h-4 w-4 animate-spin" />
+                                </>
+                            ) : (
+                                "Join Room"
+                            )}
+                        </Button>
+                    </form>
+                    {!myWebcamStream ? (
+                        <Button
+                            className="w-full cursor-pointer mt-2"
+                            variant="outline"
+                            onClick={async () => {
+                                await videoCalling.getUserMedia();
+                            }}
+                        >
+                            Start Webcam
+                        </Button>
+                    ) : (
+                        <div className="flex gap-3 items-center justify-center mt-2">
+                            <WebcamButtons shouldShowDisconnectButton={false} />
+                        </div>
+                    )}
+                </div>
             </CardContent>
         </Card>
     );

--- a/client/src/components/RoomSelection/JoinOrCreateCustomRoom.tsx
+++ b/client/src/components/RoomSelection/JoinOrCreateCustomRoom.tsx
@@ -21,9 +21,13 @@ import {
 import JoinCustomRoom from "./JoinCustomRoom";
 
 const JoinOrCreateCustomRoom = ({
+    setCarouselApi,
+    getSelectedCharacter,
     setShowPublicRoom,
     setShowCreateOrJoinCustomRoom,
 }: {
+    setCarouselApi: () => void;
+    getSelectedCharacter: () => "nancy" | "ash" | "lucy" | "adam";
     setShowPublicRoom: React.Dispatch<React.SetStateAction<boolean>>;
     setShowCreateOrJoinCustomRoom: React.Dispatch<
         React.SetStateAction<boolean>
@@ -42,6 +46,8 @@ const JoinOrCreateCustomRoom = ({
                 roomName={roomName}
                 roomId={roomId}
                 roomHasPassowrd={roomHasPassowrd}
+                getSelectedCharacter={getSelectedCharacter}
+                setCarouselApi={setCarouselApi}
                 setShowCreateOrJoinCustomRoom={setShowCreateOrJoinCustomRoom}
                 setShowJoinRoom={setShowJoinRoom}
             />
@@ -51,6 +57,8 @@ const JoinOrCreateCustomRoom = ({
     if (showCreateRoom) {
         return (
             <CreateCustomRoom
+                getSelectedCharacter={getSelectedCharacter}
+                setCarouselApi={setCarouselApi}
                 setShowCreateOrJoinCustomRoom={setShowCreateOrJoinCustomRoom}
                 setShowCreateRoom={setShowCreateRoom}
             />

--- a/client/src/components/RoomSelection/PublicRoom.tsx
+++ b/client/src/components/RoomSelection/PublicRoom.tsx
@@ -10,44 +10,35 @@ import {
     CardHeader,
     CardTitle,
 } from "../ui/card";
-import {
-    Carousel,
-    CarouselApi,
-    CarouselContent,
-    CarouselItem,
-    CarouselNext,
-    CarouselPrevious,
-} from "../ui/carousel";
 import phaserGame from "../../game/main";
 import { ArrowLeft, LoaderIcon } from "lucide-react";
+import { VideoPlayer } from "../VideoPlayer";
+import videoCalling from "../../game/service/VideoCalling";
+import store from "../../app/store";
+import { disconnectFromVideoCall } from "../../app/features/webRtc/webcamSlice";
+import { WebcamButtons } from "../FloatingActions";
+import CharacterCarousel from "./CharacterCarousel";
 import { useAppSelector } from "../../app/hooks";
 
 const PublicRoom = ({
+    setCarouselApi,
+    getSelectedCharacter,
     setShowPublicRoom,
     setShowCreateOrJoinCustomRoom,
 }: {
+    setCarouselApi: () => void;
+    getSelectedCharacter: () => "nancy" | "ash" | "lucy" | "adam";
     setShowPublicRoom: React.Dispatch<React.SetStateAction<boolean>>;
     setShowCreateOrJoinCustomRoom: React.Dispatch<
         React.SetStateAction<boolean>
     >;
 }) => {
     const bootstrap = phaserGame.scene.keys.bootstrap as Bootstrap;
-    const [api, setApi] = useState<CarouselApi>();
     const [username, setUsername] = useState<string>();
     const isLoading = useAppSelector((state) => state.room.isLoading);
-
-    const getSelectedCharacter = () => {
-        switch (api.selectedScrollSnap()) {
-            case 0:
-                return "nancy";
-            case 1:
-                return "ash";
-            case 2:
-                return "lucy";
-            case 3:
-                return "adam";
-        }
-    };
+    const myWebcamStream = useAppSelector(
+        (state) => state.webcam.myWebcamStream
+    );
 
     const handlePublicRoomJoin = (e) => {
         e.preventDefault();
@@ -62,102 +53,86 @@ const PublicRoom = ({
     };
 
     return (
-        <Card className="w-full max-w-sm">
+        <Card>
             <CardHeader>
-                <CardTitle className="relative text-2xl flex items-center justify-start gap-2">
+                <CardTitle className="relative text-2xl text-center">
                     <ArrowLeft
-                        className="cursor-pointer text-zinc-500"
+                        className="cursor-pointer text-zinc-500 absolute left-0"
                         onClick={() => {
                             setShowCreateOrJoinCustomRoom(false);
                             setShowPublicRoom(false);
+                            {
+                                myWebcamStream &&
+                                    store.dispatch(disconnectFromVideoCall());
+                            }
                         }}
                     />
                     Join Public Room
                 </CardTitle>
-                <CardDescription>
+                <CardDescription className="text-center">
                     Public rooms are for meeting new people and getting
                     familiarized with the website.
                 </CardDescription>
             </CardHeader>
-            <CardContent className="grid gap-4">
-                <div className="grid place-items-center">
-                    <Carousel
-                        setApi={setApi}
-                        opts={{ loop: true }}
-                        className="w-[60%]"
+            <CardContent className="flex gap-4 items-center">
+                {myWebcamStream && (
+                    <Card className="flex items-center justify-center">
+                        <CardContent>
+                            <VideoPlayer
+                                stream={myWebcamStream}
+                                className="w-48"
+                                muted
+                            />
+                        </CardContent>
+                    </Card>
+                )}
+                <div>
+                    <CharacterCarousel setApi={setCarouselApi} />
+                    <form
+                        className="grid gap-2"
+                        onSubmit={handlePublicRoomJoin}
                     >
-                        <CarouselContent>
-                            <CarouselItem>
-                                <div className="flex items-center justify-center bg-zinc-200 p-3 rounded-md">
-                                    <img
-                                        src="assets/characters/single/Nancy_idle_anim_20.png"
-                                        alt="Nancy"
-                                        width={50}
-                                        height={50}
-                                    />
-                                </div>
-                            </CarouselItem>
-                            <CarouselItem>
-                                <div className="flex items-center justify-center bg-zinc-200 p-3 rounded-md">
-                                    <img
-                                        src="assets/characters/single/Ash_idle_anim_20.png"
-                                        alt="Ash"
-                                        width={50}
-                                        height={50}
-                                    />
-                                </div>
-                            </CarouselItem>
-                            <CarouselItem>
-                                <div className="flex items-center justify-center bg-zinc-200 p-3 rounded-md">
-                                    <img
-                                        src="assets/characters/single/Lucy_idle_anim_20.png"
-                                        alt="Lucy"
-                                        width={50}
-                                        height={50}
-                                    />
-                                </div>
-                            </CarouselItem>
-                            <CarouselItem>
-                                <div className="flex items-center justify-center bg-zinc-200 p-3 rounded-md">
-                                    <img
-                                        src="assets/characters/single/Adam_idle_anim_20.png"
-                                        alt="Adam"
-                                        width={50}
-                                        height={50}
-                                    />
-                                </div>
-                            </CarouselItem>
-                        </CarouselContent>
-                        <CarouselPrevious className="cursor-pointer" />
-                        <CarouselNext className="cursor-pointer" />
-                    </Carousel>
+                        <Label htmlFor="username">Username</Label>
+                        <Input
+                            id="username"
+                            type="text"
+                            required
+                            value={username}
+                            onChange={(e) => {
+                                setUsername(e.target.value);
+                            }}
+                        />
+                        <Button
+                            className="w-full cursor-pointer mt-2"
+                            type="submit"
+                            disabled={isLoading}
+                        >
+                            {isLoading ? (
+                                <>
+                                    Joining Room{" "}
+                                    <LoaderIcon className="ml-2 h-4 w-4 animate-spin" />
+                                </>
+                            ) : (
+                                "Join Room"
+                            )}
+                        </Button>
+                    </form>
+                    {!myWebcamStream ? (
+                        <Button
+                            className="w-full cursor-pointer mt-2"
+                            variant="outline"
+                            onClick={async () => {
+                                await videoCalling.getUserMedia();
+                            }}
+                        >
+                            Start Webcam
+                        </Button>
+                    ) : (
+                        <div className="flex gap-3 items-center justify-center mt-2">
+                            <WebcamButtons shouldShowDisconnectButton={false} />
+                        </div>
+                    )}
                 </div>
-                <form className="grid gap-2" onSubmit={handlePublicRoomJoin}>
-                    <Label htmlFor="username">Username</Label>
-                    <Input
-                        id="username"
-                        type="text"
-                        required
-                        value={username}
-                        onChange={(e) => {
-                            setUsername(e.target.value);
-                        }}
-                    />
-                    <Button
-                        className="w-full cursor-pointer mt-2"
-                        type="submit"
-                        disabled={isLoading}
-                    >
-                        {isLoading ? (
-                            <>
-                                Joining Room{" "}
-                                <LoaderIcon className="ml-2 h-4 w-4 animate-spin" />
-                            </>
-                        ) : (
-                            "Join Room"
-                        )}
-                    </Button>
-                </form>
             </CardContent>
         </Card>
     );

--- a/client/src/components/RoomSelection/RoomSelection.tsx
+++ b/client/src/components/RoomSelection/RoomSelection.tsx
@@ -2,16 +2,33 @@ import { useState } from "react";
 import RoomDecider from "./RoomDecider";
 import PublicRoom from "./PublicRoom";
 import JoinOrCreateCustomRoom from "./JoinOrCreateCustomRoom";
+import { CarouselApi } from "../ui/carousel";
 
 const RoomSelection = () => {
     const [showPublicRoom, setShowPublicRoom] = useState(false);
     const [showCreateOrJoinCustomRoom, setShowCreateOrJoinCustomRoom] =
         useState(false);
+    const [carouselApi, setCarouselApi] = useState<CarouselApi>();
+
+    const getSelectedCharacter = () => {
+        switch (carouselApi.selectedScrollSnap()) {
+            case 0:
+                return "nancy";
+            case 1:
+                return "ash";
+            case 2:
+                return "lucy";
+            case 3:
+                return "adam";
+        }
+    };
 
     return (
         <div className="w-screen h-screen bg-zinc-50 absolute left-0 top-0 flex flex-col gap-2 items-center justify-center">
             {showPublicRoom ? (
                 <PublicRoom
+                    setCarouselApi={setCarouselApi as () => void}
+                    getSelectedCharacter={getSelectedCharacter}
                     setShowCreateOrJoinCustomRoom={
                         setShowCreateOrJoinCustomRoom
                     }
@@ -19,6 +36,8 @@ const RoomSelection = () => {
                 />
             ) : showCreateOrJoinCustomRoom ? (
                 <JoinOrCreateCustomRoom
+                    setCarouselApi={setCarouselApi as () => void}
+                    getSelectedCharacter={getSelectedCharacter}
                     setShowCreateOrJoinCustomRoom={
                         setShowCreateOrJoinCustomRoom
                     }

--- a/client/src/game/scenes/GameScene.ts
+++ b/client/src/game/scenes/GameScene.ts
@@ -167,6 +167,7 @@ export class GameScene extends Phaser.Scene {
         if (!this.network) {
             return;
         }
-        this.network.update();
+
+        this.network.update(time, delta);
     }
 }

--- a/client/src/game/scenes/Network.ts
+++ b/client/src/game/scenes/Network.ts
@@ -49,10 +49,20 @@ export default class Network {
     otherPlayers: {
         [sessionId: string]: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody;
     } = {};
+    proximityPlayers: {
+        [sessionId: string]: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody;
+    } = {};
+    private proximityTimers: {
+        [sessionId: string]: {
+            enterTime: number;
+            connected: boolean;
+        };
+    } = {};
     username: string;
     character: string;
     lastX: number;
     lastY: number;
+    static PROXIMITY_CONNECT_DELAY = 500;
 
     constructor() {
         this.client = new Client(BACKEND_URL);
@@ -191,6 +201,16 @@ export default class Network {
     startWebcam = async (shouldConnectToOtherPlayers = false) => {
         await videoCalling.getUserMedia();
 
+        if (this.currentOffice) {
+            this.shareWebcamWithOfficePlayers(shouldConnectToOtherPlayers);
+        } else {
+            this.shareWebcamWithProximityPlayer(shouldConnectToOtherPlayers);
+        }
+    };
+
+    shareWebcamWithOfficePlayers = async (
+        shouldConnectToOtherPlayers: boolean
+    ) => {
         const { members } = this.getOfficeData();
         members.forEach((username, sessionId) => {
             // preventing calling ourself
@@ -205,7 +225,25 @@ export default class Network {
         // then we need to let other players know that the current player has started his webcam again.
         // TODO: Investigate this logic....
         if (shouldConnectToOtherPlayers) {
-            this.room.send("CONNECT_TO_VIDEO_CALL", this.currentOffice);
+            this.room.send("CONNECT_TO_OFFICE_VIDEO_CALL", this.currentOffice);
+        }
+    };
+
+    shareWebcamWithProximityPlayer = async (
+        shouldConnectToOtherPlayers: boolean
+    ) => {
+        for (const sessionId in this.proximityPlayers) {
+            videoCalling.shareWebcam(sessionId);
+        }
+
+        // when player uses "Disconnect from video call button" and then turns on his camera again,
+        // then we need to let other players know that the current player has started his webcam again.
+        // TODO: Investigate this logic....
+        if (shouldConnectToOtherPlayers) {
+            this.room.send(
+                "CONNECT_TO_PROXIMITY_VIDEO_CALL",
+                Object.keys(this.proximityPlayers)
+            );
         }
     };
 
@@ -267,6 +305,8 @@ export default class Network {
      */
     private joinOffice = (officeName: officeNames) => {
         this.currentOffice = officeName;
+        this.proximityPlayers = {};
+        this.proximityTimers = {};
 
         store.dispatch(setShowOfficeChat(true));
 
@@ -297,8 +337,6 @@ export default class Network {
     };
 
     private leaveOffice = () => {
-        store.dispatch(setShowOfficeChat(false));
-
         this.room.send("LEAVE_OFFICE", {
             username: this.username,
             office: this.currentOffice,
@@ -362,6 +400,108 @@ export default class Network {
     };
 
     /**
+     * Handles proximity chat between players.
+     *
+     * The logic prioritizes disconnection checks before attempting a connection:
+     * 1. If the player moves away after the timer started, disconnect and clean up.
+     * 2. If the proximity player enters an office, disconnect immediately.
+     * 3. Only then, if the player is still near and both are outside any office, start or complete connection.
+     *
+     * This order ensures cleanup and disconnects are handled first, avoiding unnecessary
+     * connection attempts and reducing redundant proximity checks.
+     *
+     * @param time update()'s time (from Phaser's update loop)
+     * @param sessionId session ID of the proximity player
+     * @param otherPlayer the proximity player's sprite
+     */
+
+    private handleProximityChat = (
+        time: number,
+        sessionId: string,
+        otherPlayer: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody
+    ) => {
+        const distance = Phaser.Math.Distance.Between(
+            this.currentPlayer.x,
+            this.currentPlayer.y,
+            otherPlayer.x,
+            otherPlayer.y
+        );
+
+        const proximityPlayer = this.otherPlayers[sessionId];
+        const isProximityPlayerInOffice = OfficeManager.isInOffice(
+            proximityPlayer.x,
+            proximityPlayer.y
+        );
+
+        // disconnect if player was previously tracked but moved away
+        if (this.proximityTimers[sessionId] && distance > 50) {
+            const timer = this.proximityTimers[sessionId];
+
+            // player's timer was started but before connecting
+            // he moved away so no need to keep his timer anymore.
+            if (!timer.connected) {
+                delete this.proximityTimers[sessionId];
+                return;
+            }
+
+            // if moved away player was connected then disconnect with him
+            console.log("player", sessionId, "removed from proximityPlayers");
+            store.dispatch(disconnectUserForVideoCalling(sessionId));
+
+            delete this.proximityPlayers[sessionId];
+            delete this.proximityTimers[sessionId];
+
+            // notifying proximity player to disconnect with current player
+            this.room.send("REMOVE_FROM_PROXIMITY_CALL", sessionId);
+
+            return;
+        }
+
+        // disconnect if player is already connected and entered an office
+        if (this.proximityPlayers[sessionId] && isProximityPlayerInOffice) {
+            console.log("player", sessionId, "removed from proximityPlayers");
+            store.dispatch(disconnectUserForVideoCalling(sessionId));
+
+            delete this.proximityPlayers[sessionId];
+            delete this.proximityTimers[sessionId];
+
+            // notifying proximity player to disconnect with current player
+            this.room.send("REMOVE_FROM_PROXIMITY_CALL", sessionId);
+
+            return;
+        }
+
+        // connect if near and both are not in office
+        if (
+            distance <= 50 &&
+            !this.currentOffice &&
+            !isProximityPlayerInOffice
+        ) {
+            // player just came near the current player, start his timer and return
+            if (!this.proximityTimers[sessionId]) {
+                this.proximityTimers[sessionId] = {
+                    enterTime: time,
+                    connected: false,
+                };
+                return;
+            }
+
+            // player is near for enough time and is not already connected
+            // only then connect with him
+            const timer = this.proximityTimers[sessionId];
+            if (
+                !timer.connected &&
+                time - timer.enterTime >= Network.PROXIMITY_CONNECT_DELAY
+            ) {
+                this.proximityPlayers[sessionId] = otherPlayer;
+                timer.connected = true;
+                console.log("player", sessionId, "added to proximityPlayers");
+                videoCalling.shareWebcam(sessionId);
+            }
+        }
+    };
+
+    /**
      * Stops screen sharing.
      *
      * Letting other players know that the current player
@@ -383,7 +523,14 @@ export default class Network {
         // TODO: Add a common folder between server & client where all types can be declared.
         // because currentOffice can be set to invalid string which server cannot handle.
         store.dispatch(disconnectFromVideoCall());
-        this.room.send("USER_STOPPED_WEBCAM", this.currentOffice);
+        if (this.currentOffice) {
+            this.room.send("USER_STOPPED_OFFICE_WEBCAM", this.currentOffice);
+        } else {
+            this.room.send(
+                "USER_STOPPED_PROXIMITY_WEBCAM",
+                Object.keys(this.proximityPlayers)
+            );
+        }
     };
 
     /**
@@ -515,15 +662,32 @@ export default class Network {
             videoCalling.shareWebcam(playerSessionId);
         });
 
-        this.room.onMessage("NEW_GLOBAL_CHAT_MESSAGE", (serverData) => {
-            store.dispatch(
-                pushNewGlobalMessage({
-                    username: serverData.username,
-                    message: serverData.message,
-                    type: serverData.type,
-                })
-            );
-        });
+        this.room.onMessage(
+            "NEW_GLOBAL_CHAT_MESSAGE",
+            ({ sessionId, username, message, type }) => {
+                // sessionId is sent only with player left game message
+                // otherwise it is not required.
+
+                store.dispatch(
+                    pushNewGlobalMessage({
+                        username,
+                        message,
+                        type,
+                    })
+                );
+
+                // if a player left then check if he was a proximity chat player
+                // if he was then disconnect with him from Video Call
+                if (
+                    type === "PLAYER_LEFT" &&
+                    this.proximityPlayers[sessionId]
+                ) {
+                    store.dispatch(disconnectUserForVideoCalling(sessionId));
+                    delete this.proximityPlayers[sessionId];
+                    delete this.proximityTimers[sessionId];
+                }
+            }
+        );
 
         this.room.onMessage("GET_GLOBAL_CHAT", (globalChatMessages) => {
             const allMessages = globalChatMessages.map((msg) => {
@@ -541,7 +705,7 @@ export default class Network {
             store.dispatch(disconnectUserForScreenSharing(userId));
         });
 
-        this.room.onMessage("USER_STOPPED_WEBCAM", (userId) => {
+        this.room.onMessage("END_VIDEO_CALL_WITH_USER", (userId) => {
             store.dispatch(disconnectUserForVideoCalling(userId));
         });
 
@@ -557,7 +721,7 @@ export default class Network {
     /**
      * Handles real-time movements of player.
      */
-    update = () => {
+    update = (time: number, delta: number) => {
         if (!this.currentPlayer) {
             return;
         }
@@ -567,12 +731,11 @@ export default class Network {
         const { x, y } = this.currentPlayer;
 
         if (x !== this.lastX || y !== this.lastY) {
-            const zone = this.officeManager.update(x, y);
+            const office = this.officeManager.update(x, y);
 
-            if (zone && this.currentOffice !== zone) {
-                this.currentOffice = zone;
-                this.joinOffice(zone);
-            } else if (!zone && this.currentOffice) {
+            if (office && this.currentOffice !== office) {
+                this.joinOffice(office);
+            } else if (!office && this.currentOffice) {
                 this.leaveOffice();
             }
 
@@ -581,7 +744,7 @@ export default class Network {
         }
 
         // interpolate other players.
-        for (let sessionId in this.otherPlayers) {
+        for (const sessionId in this.otherPlayers) {
             // skipping current player
             if (sessionId === this.room.sessionId) continue;
 
@@ -592,6 +755,8 @@ export default class Network {
                 entity.y = Phaser.Math.Linear(entity.y, serverY, 0.2);
                 entity.anims.play(anim, true);
             }
+
+            this.handleProximityChat(time, sessionId, entity);
         }
     };
 }

--- a/client/src/game/scenes/OfficeManager.ts
+++ b/client/src/game/scenes/OfficeManager.ts
@@ -76,4 +76,21 @@ export class OfficeManager {
 
         return null;
     }
+
+    /**
+     * Checks if a player is inside an office or not.
+     *
+     * @param x player's x position
+     * @param y player's y position
+     * @returns true if player is inside an office otherwise false
+     */
+    public static isInOffice(x: number, y: number): boolean {
+        for (const office of OfficeManager.OFFICES) {
+            if (Phaser.Geom.Rectangle.Contains(office.rect, x, y)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/client/src/game/service/VideoCalling.ts
+++ b/client/src/game/service/VideoCalling.ts
@@ -47,6 +47,7 @@ class VideoCalling {
             });
 
             peer.on("call", (call) => {
+                console.log("video call received from", call.peer);
                 call.answer();
                 call.on("stream", (userStream) => {
                     store.dispatch(


### PR DESCRIPTION
There are 2 commits in the PR.

**First commit:**
- Added support for proximity chat
- Users can talk with other users via video call without joining office
- users gets automatically connected to the near user's video call
- user needs to stay near for minimum 500ms to get connected to the proximity video call
- I have kept `Disconnect from video calls` button even for proximity chat, which user can to disconnect from proximity chat, upon using it, user's webcam will be turned off and he will also get disconnected from all the proximity calls and he'll not receive any further calls as well
- to re-connect with calls, he can turn on his webcam again
- when current user or other user moves away, they gets disconnected from video call
- when a user enters an office then proximity chat gets disabled, he gets disconnected from proximity video calls and gets connected to the office's video calls
- `handleProximityChat` is the method for handling proximity chat
- Some new server messages are added for handling proximity chat


**Second commit:**
- Now that we have support for proximity chat, I added a button to start the webcam before joining the room
- User can turn on/off their mic/video before joining the room

**Extras:**
- Removed extra console logs from chatSlice.ts