### PR TITLE
Add loaders for joining rooms and initial lobby connection

### DIFF
--- a/client/src/app/features/room/roomSlice.ts
+++ b/client/src/app/features/room/roomSlice.ts
@@ -7,6 +7,7 @@ const initialState = {
         roomId: string;
         hasPassword: boolean;
     }>(),
+    isLoading: true,
 };
 
 const roomSlice = createSlice({
@@ -31,10 +32,17 @@ const roomSlice = createSlice({
                 (room) => room.roomId !== action.payload
             );
         },
+        setIsLoading: (state, action: PayloadAction<boolean>) => {
+            state.isLoading = action.payload;
+        },
     },
 });
 
-export const { setRoomJoined, addAvailableRooms, removeFromAvailableRooms } =
-    roomSlice.actions;
+export const {
+    setRoomJoined,
+    addAvailableRooms,
+    removeFromAvailableRooms,
+    setIsLoading,
+} = roomSlice.actions;
 
 export default roomSlice.reducer;

--- a/client/src/components/RoomSelection/CreateCustomRoom.tsx
+++ b/client/src/components/RoomSelection/CreateCustomRoom.tsx
@@ -19,7 +19,8 @@ import {
     CarouselPrevious,
 } from "../ui/carousel";
 import phaserGame from "../../game/main";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, LoaderIcon } from "lucide-react";
+import { useAppSelector } from "../../app/hooks";
 
 const CreateCustomRoom = ({
     setShowCreateOrJoinCustomRoom,
@@ -35,6 +36,7 @@ const CreateCustomRoom = ({
     const [username, setUsername] = useState<string>();
     const [roomName, setRoomName] = useState<string>();
     const [password, setPassword] = useState<string>(null);
+    const isLoading = useAppSelector((state) => state.room.isLoading);
 
     const getSelectedCharacter = () => {
         switch (api.selectedScrollSnap()) {
@@ -171,8 +173,16 @@ const CreateCustomRoom = ({
                     <Button
                         className="w-full cursor-pointer mt-2"
                         type="submit"
+                        disabled={isLoading}
                     >
-                        Create Room
+                        {isLoading ? (
+                            <>
+                                Creating Room{" "}
+                                <LoaderIcon className="ml-2 h-4 w-4 animate-spin" />
+                            </>
+                        ) : (
+                            "Create Room"
+                        )}
                     </Button>
                 </form>
             </CardContent>

--- a/client/src/components/RoomSelection/JoinCustomRoom.tsx
+++ b/client/src/components/RoomSelection/JoinCustomRoom.tsx
@@ -2,7 +2,7 @@ import { Input } from "../ui/input";
 import { Label } from "../ui/label";
 import { Bootstrap } from "../../game/scenes/Bootstrap";
 import { Button } from "../ui/button";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, LoaderIcon } from "lucide-react";
 import { useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import {
@@ -14,6 +14,7 @@ import {
     CarouselPrevious,
 } from "../ui/carousel";
 import phaserGame from "../../game/main";
+import { useAppSelector } from "../../app/hooks";
 
 const JoinCustomRoom = ({
     roomName,
@@ -34,6 +35,7 @@ const JoinCustomRoom = ({
     const [api, setApi] = useState<CarouselApi>();
     const [username, setUsername] = useState<string>();
     const [password, setPassword] = useState<string>(null);
+    const isLoading = useAppSelector((state) => state.room.isLoading);
 
     const getSelectedCharacter = () => {
         switch (api.selectedScrollSnap()) {
@@ -152,8 +154,16 @@ const JoinCustomRoom = ({
                     <Button
                         className="w-full cursor-pointer mt-2"
                         type="submit"
+                        disabled={isLoading}
                     >
-                        Join Room
+                        {isLoading ? (
+                            <>
+                                Joining Room{" "}
+                                <LoaderIcon className="ml-2 h-4 w-4 animate-spin" />
+                            </>
+                        ) : (
+                            "Join Room"
+                        )}
                     </Button>
                 </form>
             </CardContent>

--- a/client/src/components/RoomSelection/PublicRoom.tsx
+++ b/client/src/components/RoomSelection/PublicRoom.tsx
@@ -19,7 +19,8 @@ import {
     CarouselPrevious,
 } from "../ui/carousel";
 import phaserGame from "../../game/main";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, LoaderIcon } from "lucide-react";
+import { useAppSelector } from "../../app/hooks";
 
 const PublicRoom = ({
     setShowPublicRoom,
@@ -33,6 +34,7 @@ const PublicRoom = ({
     const bootstrap = phaserGame.scene.keys.bootstrap as Bootstrap;
     const [api, setApi] = useState<CarouselApi>();
     const [username, setUsername] = useState<string>();
+    const isLoading = useAppSelector((state) => state.room.isLoading);
 
     const getSelectedCharacter = () => {
         switch (api.selectedScrollSnap()) {
@@ -144,8 +146,16 @@ const PublicRoom = ({
                     <Button
                         className="w-full cursor-pointer mt-2"
                         type="submit"
+                        disabled={isLoading}
                     >
-                        Join
+                        {isLoading ? (
+                            <>
+                                Joining Room{" "}
+                                <LoaderIcon className="ml-2 h-4 w-4 animate-spin" />
+                            </>
+                        ) : (
+                            "Join Room"
+                        )}
                     </Button>
                 </form>
             </CardContent>

--- a/client/src/components/RoomSelection/RoomDecider.tsx
+++ b/client/src/components/RoomSelection/RoomDecider.tsx
@@ -1,5 +1,7 @@
+import { useAppSelector } from "../../app/hooks";
 import { Button } from "../ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
+import { Skeleton } from "../ui/skeleton";
 
 const RoomDecider = ({
     setShowPublicRoom,
@@ -10,34 +12,54 @@ const RoomDecider = ({
         React.SetStateAction<boolean>
     >;
 }) => {
+    const isLoading = useAppSelector((state) => state.room.isLoading);
+
+    if (isLoading) {
+        return (
+            <Card className="w-full max-w-sm">
+                <CardHeader>
+                    <CardTitle className="text-2xl text-center">
+                        Connecting to the server
+                    </CardTitle>
+                </CardHeader>
+                <CardContent className="grid gap-4">
+                    <Skeleton className="h-10 rounded-lg animate-pulse" />
+                    <Skeleton className="h-10 rounded-lg animate-pulse" />
+                </CardContent>
+            </Card>
+        );
+    }
+
     return (
-        <Card className="w-full max-w-sm">
-            <CardHeader>
-                <CardTitle className="text-2xl text-center">
-                    Welcome to CaveVerse
-                </CardTitle>
-            </CardHeader>
-            <CardContent className="grid gap-4">
-                <Button
-                    className="w-full cursor-pointer"
-                    onClick={() => {
-                        setShowPublicRoom(true);
-                        setShowCreateOrJoinCustomRoom(false);
-                    }}
-                >
-                    Join Public Room
-                </Button>
-                <Button
-                    className="w-full cursor-pointer"
-                    onClick={() => {
-                        setShowCreateOrJoinCustomRoom(true);
-                        setShowPublicRoom(false);
-                    }}
-                >
-                    Join/Create Custom Room
-                </Button>
-            </CardContent>
-        </Card>
+        <>
+            <Card className="w-full max-w-sm">
+                <CardHeader>
+                    <CardTitle className="text-2xl text-center">
+                        Welcome to CaveVerse
+                    </CardTitle>
+                </CardHeader>
+                <CardContent className="grid gap-4">
+                    <Button
+                        className="w-full cursor-pointer"
+                        onClick={() => {
+                            setShowPublicRoom(true);
+                            setShowCreateOrJoinCustomRoom(false);
+                        }}
+                    >
+                        Join Public Room
+                    </Button>
+                    <Button
+                        className="w-full cursor-pointer"
+                        onClick={() => {
+                            setShowCreateOrJoinCustomRoom(true);
+                            setShowPublicRoom(false);
+                        }}
+                    >
+                        Join/Create Custom Room
+                    </Button>
+                </CardContent>
+            </Card>
+        </>
     );
 };
 

--- a/client/src/components/ui/skeleton.tsx
+++ b/client/src/components/ui/skeleton.tsx
@@ -1,0 +1,14 @@
+import { cn } from "../../lib/utils";
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+    return (
+        <div
+            data-slot="skeleton"
+            className={cn("bg-accent animate-pulse rounded-md", className)}
+            {...props}
+        />
+    );
+}
+
+export { Skeleton };
+

--- a/client/src/game/scenes/Network.ts
+++ b/client/src/game/scenes/Network.ts
@@ -7,6 +7,7 @@ import screenSharing from "../service/ScreenSharing";
 import {
     addAvailableRooms,
     removeFromAvailableRooms,
+    setIsLoading,
 } from "../../app/features/room/roomSlice";
 import {
     addGlobalChat,
@@ -70,6 +71,7 @@ export default class Network {
      */
     joinLobbyRoom = async () => {
         this.lobby = await this.client.joinOrCreate("LOBBY_ROOM");
+        store.dispatch(setIsLoading(false));
 
         this.lobby.onMessage("rooms", (rooms) => {
             rooms.forEach((room) => {
@@ -118,6 +120,7 @@ export default class Network {
      * @param character selected avatar
      */
     joinOrCreatePublicRoom = async (username: string, character: string) => {
+        store.dispatch(setIsLoading(true));
         this.username = username;
         this.character = character;
         this.room = await this.client.joinOrCreate("PUBLIC_ROOM", {
@@ -125,6 +128,7 @@ export default class Network {
             character: this.character,
         });
         this.lobby.leave();
+        store.dispatch(setIsLoading(false));
     };
 
     /**
@@ -141,6 +145,7 @@ export default class Network {
         password: string | null,
         character: string
     ) => {
+        store.dispatch(setIsLoading(true));
         this.username = username;
         this.character = character;
         this.room = await this.client.create("PRIVATE_ROOM", {
@@ -149,6 +154,7 @@ export default class Network {
             username: this.username,
         });
         this.lobby.leave();
+        store.dispatch(setIsLoading(false));
     };
 
     /**
@@ -165,6 +171,7 @@ export default class Network {
         password: string | null,
         character: string
     ) => {
+        store.dispatch(setIsLoading(true));
         this.username = username;
         this.character = character;
         console.log("room Id: ", roomId);
@@ -173,6 +180,7 @@ export default class Network {
             username: this.username,
         });
         this.lobby.leave();
+        store.dispatch(setIsLoading(false));
     };
 
     /**


### PR DESCRIPTION
Previously, there was no loader when users clicked the Join or Create Room button, allowing multiple clicks. This caused multiple characters to be created and led to chat glitches.

This update introduces:

- A loader on the Join/Create Room buttons to prevent multiple clicks and ensure only one character is created.

- A skeleton loader when visiting the website, shown until the user successfully connects to the lobby room, improving the initial loading experience.